### PR TITLE
#18 - Add Environments

### DIFF
--- a/functionary/builder/models/build.py
+++ b/functionary/builder/models/build.py
@@ -1,9 +1,10 @@
 """ Build model """
 import uuid
 
+from django.conf import settings
 from django.db import models
 
-from core.models import Package, User
+from core.models import Package
 
 
 class Build(models.Model):
@@ -32,7 +33,9 @@ class Build(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     created_at = models.DateTimeField(auto_now_add=True, db_index=True)
     updated_at = models.DateTimeField(auto_now_add=True, db_index=True)
-    creator = models.ForeignKey(to=User, on_delete=models.CASCADE, db_index=True)
+    creator = models.ForeignKey(
+        to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE, db_index=True
+    )
     status = models.CharField(max_length=16, choices=STATUS_CHOICES, default=PENDING)
     package = models.ForeignKey(
         to=Package, on_delete=models.CASCADE, blank=True, null=True

--- a/functionary/core/admin/__init__.py
+++ b/functionary/core/admin/__init__.py
@@ -1,10 +1,11 @@
 from django.contrib import admin
 from django.contrib.auth.models import Group
 
-from core.models import Function, Package, Team, TeamMember, User
+from core.models import Environment, Function, Package, Team, TeamMember, User
 
 from .user import UserAdmin
 
+admin.site.register(Environment, admin.ModelAdmin)
 admin.site.register(Function, admin.ModelAdmin)
 admin.site.register(Package, admin.ModelAdmin)
 admin.site.register(Team, admin.ModelAdmin)

--- a/functionary/core/api/v1/serializers/team.py
+++ b/functionary/core/api/v1/serializers/team.py
@@ -1,12 +1,22 @@
 """ Team serializers """
 from rest_framework import serializers
 
-from core.models import Team
+from core.models import Environment, Team
+
+
+class TeamEnvironmentSerializer(serializers.ModelSerializer):
+    """Serializer for listing a Team's environments"""
+
+    class Meta:
+        model = Environment
+        fields = ["id", "name", "default"]
 
 
 class TeamSerializer(serializers.ModelSerializer):
     """Basic serializer for the Team model"""
 
+    environments = TeamEnvironmentSerializer(many=True)
+
     class Meta:
         model = Team
-        fields = ["id", "name"]
+        fields = ["id", "name", "environments"]

--- a/functionary/core/models/__init__.py
+++ b/functionary/core/models/__init__.py
@@ -1,3 +1,4 @@
+from .environment import Environment  # noqa
 from .function import Function  # noqa
 from .package import Package  # noqa
 from .team import Team  # noqa

--- a/functionary/core/models/environment.py
+++ b/functionary/core/models/environment.py
@@ -1,0 +1,58 @@
+""" Environment model """
+import uuid
+from typing import TYPE_CHECKING
+
+from django.db import models
+
+if TYPE_CHECKING:
+    from core.models import Team
+
+
+class Environment(models.Model):
+    """Second tier of a namespacing under Team. Environments act as the primary point
+    of association for packages, tasks, etc.
+
+    Attributes:
+        id: unique identifier (UUID)
+        name: the name of the environment
+        team: the Team that this environment belongs to
+        default: when true, this environment will act as the default for a Team in
+                 cases where an environment is not specified.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=64)
+    team = models.ForeignKey(
+        to="Team", related_name="environments", on_delete=models.CASCADE, db_index=True
+    )
+    default = models.BooleanField(default=False)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["team", "name"], name="team_name_unique_together"
+            ),
+            models.UniqueConstraint(
+                fields=["team", "default"],
+                condition=models.Q(default=True),
+                name="team_default_true_unique_together",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.team.name} - {self.name}"
+
+    @classmethod
+    def create_default(cls, team: "Team") -> "Environment":
+        """Create a default environment for the provided Team
+
+        Args:
+            team: Team to which the created environment will belong and be the default
+
+        Returns:
+            The created Environment
+        """
+        environment = cls.objects.create(name="default", team=team, default=True)
+        environment.save()
+
+        return environment

--- a/functionary/core/models/environment.py
+++ b/functionary/core/models/environment.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from django.db import models
 
+# Avoid circular import when import is needed only for type checking
 if TYPE_CHECKING:
     from core.models import Team
 

--- a/functionary/core/models/function.py
+++ b/functionary/core/models/function.py
@@ -14,8 +14,6 @@ class Function(models.Model):
         display_name: optional display name
         description: more details about the function
         schema: the function's OpenAPI definition
-        active: whether this function is the one that is taskable. False indicates that
-                this is a historical entry.
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
@@ -28,21 +26,10 @@ class Function(models.Model):
     description = models.TextField(null=True)
     schema = models.JSONField()
 
-    # TODO: Add validation so that only one entry sharing a package and name can be
-    #       active
-    active = models.BooleanField(default=True, blank=False, null=False)
-
     class Meta:
         constraints = [
             models.UniqueConstraint(
                 fields=["package", "name"], name="package_name_unique_together"
-            )
-        ]
-        indexes = [
-            models.Index(
-                fields=["package", "active"],
-                condition=models.Q(active=True),
-                name="package_active_true_index",
             )
         ]
 

--- a/functionary/core/models/package.py
+++ b/functionary/core/models/package.py
@@ -4,6 +4,8 @@ import uuid
 from django.conf import settings
 from django.db import models
 
+from core.models import Environment
+
 
 class Package(models.Model):
     """A Package is a grouping of functions made available for tasking
@@ -17,7 +19,7 @@ class Package(models.Model):
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    team = models.ForeignKey(to="Team", on_delete=models.CASCADE)
+    environment = models.ForeignKey(to=Environment, on_delete=models.CASCADE)
 
     # TODO: This shouldn't be changeable after creation
     name = models.CharField(max_length=64, blank=False)
@@ -33,7 +35,7 @@ class Package(models.Model):
     class Meta:
         constraints = [
             models.UniqueConstraint(
-                fields=["team", "name"], name="team_name_unique_together"
+                fields=["environment", "name"], name="environment_name_unique_together"
             )
         ]
 

--- a/functionary/functionary/settings/django_.py
+++ b/functionary/functionary/settings/django_.py
@@ -26,9 +26,12 @@ SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(util.strtobool(os.environ.get("DEBUG", "false")))
 
-
-ALLOWED_HOSTS = []
-
+# Required if DEBUG is False
+ALLOWED_HOSTS_ENV = os.environ.get("ALLOWED_HOSTS")
+if ALLOWED_HOSTS_ENV is None:
+    ALLOWED_HOSTS = []
+else:
+    ALLOWED_HOSTS = list(map(lambda host: host.strip(), ALLOWED_HOSTS_ENV.split(",")))
 
 # Application definition
 INSTALLED_APPS = [

--- a/functionary/requirements.in
+++ b/functionary/requirements.in
@@ -2,6 +2,7 @@ celery
 django
 docker
 pyyaml
+redis
 
 # drf and optional dependencies
 djangorestframework

--- a/functionary/requirements.txt
+++ b/functionary/requirements.txt
@@ -8,6 +8,8 @@ amqp==5.1.1
     # via kombu
 asgiref==3.5.2
     # via django
+async-timeout==4.0.2
+    # via redis
 attrs==22.1.0
     # via jsonschema
 billiard==3.6.4.0
@@ -30,6 +32,8 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
+deprecated==1.2.13
+    # via redis
 django==4.0.6
     # via
     #   -r requirements.in
@@ -54,8 +58,12 @@ jsonschema==4.8.0
     # via drf-spectacular
 kombu==5.2.4
     # via celery
+packaging==21.3
+    # via redis
 prompt-toolkit==3.0.30
     # via click-repl
+pyparsing==3.0.9
+    # via packaging
 pyrsistent==0.18.1
     # via jsonschema
 pytz==2022.1
@@ -66,6 +74,8 @@ pyyaml==6.0
     # via
     #   -r requirements.in
     #   drf-spectacular
+redis==4.3.4
+    # via -r requirements.in
 requests==2.28.1
     # via docker
 six==1.16.0
@@ -85,3 +95,5 @@ wcwidth==0.2.5
     # via prompt-toolkit
 websocket-client==1.3.3
     # via docker
+wrapt==1.14.1
+    # via deprecated


### PR DESCRIPTION
Closes #18 

This PR establishes the Environments model and replaces most references to a Team with an association to an Environment instead.  Other changes of note:

* The Team model has been updated to create a default environment when a Team is created.
* The `/api/v1/teams` endpoint now returns a list of environments for the team.
* The `/api/v1/publish` endpoint now accepts an X-Environment-Id *or* an X-Team-Id.  If only X-Team-Id is provided, the environment is set to the default environment for that Team.  This interaction will be generalized in a future PR (the logic for this does not belong on individual endpoints).