### PR TITLE
Created EnvironmentViewMixin to centralize request environment handling

### DIFF
--- a/functionary/builder/api/v1/views/publish.py
+++ b/functionary/builder/api/v1/views/publish.py
@@ -1,4 +1,4 @@
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from drf_spectacular.utils import extend_schema
 from rest_framework import permissions
 from rest_framework.exceptions import ParseError
 from rest_framework.parsers import MultiPartParser
@@ -6,12 +6,12 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from builder.utils import extract_package_definition, initiate_build
-from core.models import Environment
+from core.api.mixins import EnvironmentViewMixin
 
 from ..serializers import BuildSerializer, PackageDefinitionSerializer
 
 
-class PublishView(APIView):
+class PublishView(APIView, EnvironmentViewMixin):
     """View for submitting a package to be built and published."""
 
     # TODO: Authentication and permissions
@@ -35,14 +35,7 @@ class PublishView(APIView):
             }
         },
         responses={200: BuildSerializer},
-        parameters=[
-            OpenApiParameter(
-                name="X-Team-Id", type=str, location=OpenApiParameter.HEADER
-            ),
-            OpenApiParameter(
-                name="X-Environment-Id", type=str, location=OpenApiParameter.HEADER
-            ),
-        ],
+        parameters=EnvironmentViewMixin.header_parameters,
     )
     def post(self, request, *args, **kwargs):
         """Receives the package contents and package definition files. The definition
@@ -52,6 +45,7 @@ class PublishView(APIView):
         # request data ourselves
         self._validate_publish_input(request)
 
+        environment = self.get_environment()
         package_contents_blob = request.FILES.get("package_contents").read()
         package_yaml = extract_package_definition(package_contents_blob)
 
@@ -63,20 +57,9 @@ class PublishView(APIView):
             raise_exception=True
         )
 
-        # TODO: request.team and request.environment should be set automatically on
-        #       every request via a mixin or similar solution
-        environment_id = request.headers.get("X-Environment-Id")
-        if environment_id is None:
-            team_id = request.headers.get("X-Team-Id")
-            request.environment = Environment.objects.get(
-                team__id=team_id, default=True
-            )
-        else:
-            request.environment = Environment.objects.get(id=environment_id)
-
         build = initiate_build(
             creator=request.user,
-            environment=request.environment,
+            environment=environment,
             package_contents=package_contents_blob,
             package_definition=package_definition,
             package_definition_version=package_yaml.get("version", "1.0"),

--- a/functionary/core/api/mixins.py
+++ b/functionary/core/api/mixins.py
@@ -1,0 +1,74 @@
+from django.core.exceptions import ValidationError
+from drf_spectacular.utils import OpenApiParameter
+from rest_framework.exceptions import APIException
+
+from core.models import Environment, Team
+
+
+# TODO: Move to some central exceptions module
+class InvalidHeader(APIException):
+    status_code = 400
+    default_detail = "Required header is missing or invalid"
+    default_code = "bad_request"
+
+
+class EnvironmentViewMixin:
+    """Provides handling of the X-Environment-Id and X-Team-Id headers to determine
+    the environment context of the request."""
+
+    header_parameters = [
+        OpenApiParameter(
+            name="X-Team-Id",
+            type=str,
+            location=OpenApiParameter.HEADER,
+            description=(
+                "ID for the Team to which this request corresponds. If set, the "
+                "default environment for the team will be used. This is ignored if "
+                "X-Environment-Id is set."
+            ),
+        ),
+        OpenApiParameter(
+            name="X-Environment-Id",
+            type=str,
+            location=OpenApiParameter.HEADER,
+            description=("ID for the Environment to which this request corresponds"),
+        ),
+    ]
+
+    def get_environment(self) -> Environment:
+        """Retrieve the Environment object that corresponds to either the environment
+        with id X-Environment-Id or the default environment for the team with id
+        X-Team-Id.
+
+        Returns:
+            The appropriate Environment object based on the request headers
+
+        Raises:
+            InvalidHeader: The headers were missing or the environment could not be
+                           determined based on the header values
+        """
+        environment_id = self.request.headers.get("X-Environment-Id")
+        team_id = self.request.headers.get("X-Team-Id")
+
+        if environment_id:
+            try:
+                environment_obj = Environment.objects.get(id=environment_id)
+            except (Environment.DoesNotExist, ValidationError):
+                raise InvalidHeader(f"No environment found with id {environment_id}")
+        elif team_id:
+            try:
+                team_obj = Team.objects.get(id=team_id)
+            except (Team.DoesNotExist, ValidationError):
+                raise InvalidHeader(f"No team found with id {team_id}")
+
+            try:
+                environment_obj = team_obj.environments.get(default=True)
+            except Environment.DoesNotExist:
+                raise InvalidHeader(
+                    f"No default environment for team {team_id}. "
+                    "X-Environment-Id header is required."
+                )
+        else:
+            raise InvalidHeader("X-Environment-Id or X-Team-Id header must be set")
+
+        return environment_obj


### PR DESCRIPTION
Closes #20 

This PR adds a mixin to handle the X-Team-Id and X-Environment-Id headers so that the logic can be reused across all of the relevant views.