### PR TITLE
#17 - Update CLI login and publish commands

### DIFF
--- a/cli/functionary/login.py
+++ b/cli/functionary/login.py
@@ -15,7 +15,7 @@ def login_cmd(ctx, user, password, host):
     Set the output of this command to the FUNCTIONARY_TOKEN environment variable
     for other functionary commands to use to communicate with the server.
     """
-    login_url = f"{host}/api/token/"
+    login_url = f"{host}/api/v1/api-token-auth"
     success, message = login(login_url, user, password)
 
     # check status code/message on return then exit

--- a/cli/functionary/tokens.py
+++ b/cli/functionary/tokens.py
@@ -17,12 +17,9 @@ def login(login_url: str, user: str, password: str):
         login_response = requests.post(
             f"{login_url}", data={"username": user, "password": password}
         )
-
         # check status code/message on return then exit
         if login_response.ok:
             tokens = json.loads(login_response.text)
-            tokens["token"] = tokens["access"]
-            tokens["login_url"] = login_url
             saveTokens(tokens)
             success = True
         else:
@@ -48,10 +45,7 @@ def saveTokens(tokens):
 
     tokensFile = functionaryDir / "tokens"
     with tokensFile.open("wt"):
-        tokensFile.write_text(
-            f"token={tokens['token']}\n"
-            f"login_url={tokens['login_url']}"
-        )
+        tokensFile.write_text(f"token={tokens['token']}\n")
 
 
 def getToken():

--- a/functionary/builder/utils.py
+++ b/functionary/builder/utils.py
@@ -44,7 +44,7 @@ def extract_package_definition(package_contents: bytes) -> dict:
         tarball.close()
 
     try:
-        package_definition_io = tarball.extractfile("./package.yaml")
+        package_definition_io = tarball.extractfile("package.yaml")
     except KeyError:
         # TODO: Raise custom, useful exception
         close_files()


### PR DESCRIPTION
Closes #17 

-The login command now hits the /api/v1/api-token-auth endpoint to retrieve the token.
-The header that gets set to use the token prefixes the token with "Token" rather than "Bearer"
-The package tarball puts the files at the root of the structure rather than nested in a subdirectory
--The package tarball is sent to /api/v1/publish and the request includes the X-Environment-Id header.