### PR TITLE
Fix first party module issue in isort github action

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -34,8 +34,12 @@ jobs:
           linters: flake8
           run: flake8
 
+
   isort:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        component: [functionary, cli, runner]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -44,12 +48,12 @@ jobs:
         with:
           python-version: "3.10"
       - run: python -m pip install isort
-      - name: isort
+      - name: isort ${{ matrix.component }}
         # Adds annotations to PRs
         uses: liskin/gh-problem-matcher-wrap@v1
         with:
           linters: isort
-          run: isort --check --diff --resolve-all-configs .
+          run: isort --check --diff ${{ matrix.component }}
 
   black:
     runs-on: ubuntu-latest

--- a/functionary/builder/utils.py
+++ b/functionary/builder/utils.py
@@ -5,6 +5,7 @@ import shutil
 import tarfile
 from uuid import UUID
 
+import docker
 import yaml
 from celery.utils.log import get_task_logger
 from django.apps import apps
@@ -13,7 +14,6 @@ from django.db import transaction
 from django.template import Context, Engine
 from pydantic import Field, create_model
 
-import docker
 from core.models import Environment, Function, Package, User
 
 from .celery import app


### PR DESCRIPTION
This PR changes the github action to run isort on the directories individually rather than all at once to fix an issue where "docker" was being treated as a first party module, since there is a "docker" folder at the root of the repo.