### PR TITLE
Correct auth Enum names to be singular

### DIFF
--- a/functionary/core/auth/__init__.py
+++ b/functionary/core/auth/__init__.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class Permissions(Enum):
+class Permission(Enum):
     """Enum containing permissions, which consist of one for each of the CRUD
     operations per model. Examples:
 
@@ -14,8 +14,8 @@ class Permissions(Enum):
     as either the enum or its value:
 
         # both of these are valid
-        user.has_perm(Permissions.FUNCTION_READ, environment)
-        user.has_perm(Permissions.FUNCTION_READ.value, environment)
+        user.has_perm(Permission.FUNCTION_READ, environment)
+        user.has_perm(Permission.FUNCTION_READ.value, environment)
     """
 
     ENVIRONMENT_CREATE = "environment:create"
@@ -49,7 +49,7 @@ class Permissions(Enum):
     USERROLE_DELETE = "userrole:delete"
 
 
-class Roles(Enum):
+class Role(Enum):
     """Enum containing assignable roles"""
 
     ADMIN = "admin"
@@ -59,17 +59,17 @@ class Roles(Enum):
 
 
 # ADMIN gets all permissions
-_ADMIN_PERMISSIONS = [permission.value for permission in Permissions]
+_ADMIN_PERMISSIONS = [permission.value for permission in Permission]
 
 # READ_ONLY gets read access to all models
 _READ_ONLY_PERMISSIONS = [
-    permission.value for permission in Permissions if ":read" in permission.value
+    permission.value for permission in Permission if ":read" in permission.value
 ]
 
 # Other roles get build on READ_ONLY
 _DEVELOPER_PERMISSIONS = _READ_ONLY_PERMISSIONS + [
-    Permissions.PACKAGE_CREATE.value,
-    Permissions.PACKAGE_UPDATE.value,
+    Permission.PACKAGE_CREATE.value,
+    Permission.PACKAGE_UPDATE.value,
 ]
 
 # TODO: Add permissions once Task model exists
@@ -77,8 +77,8 @@ _OPERATOR_PERMISSIONS = _READ_ONLY_PERMISSIONS + []
 
 
 ROLE_PERMISSION_MAP = {
-    Roles.ADMIN.name: _ADMIN_PERMISSIONS,
-    Roles.DEVELOPER.name: _DEVELOPER_PERMISSIONS,
-    Roles.READ_ONLY.name: _READ_ONLY_PERMISSIONS,
-    Roles.OPERATOR.name: _OPERATOR_PERMISSIONS,
+    Role.ADMIN.name: _ADMIN_PERMISSIONS,
+    Role.DEVELOPER.name: _DEVELOPER_PERMISSIONS,
+    Role.READ_ONLY.name: _READ_ONLY_PERMISSIONS,
+    Role.OPERATOR.name: _OPERATOR_PERMISSIONS,
 }

--- a/functionary/core/auth/backends.py
+++ b/functionary/core/auth/backends.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.backends import BaseBackend
 
-from core.auth import Permissions
+from core.auth import Permission
 from core.models import Environment, Team
 
 
@@ -22,7 +22,7 @@ class CoreBackend(BaseBackend):
 
         Args:
             user: User object
-            perm: A string or Permissions enum representing the permission to check
+            perm: A string or Permission enum representing the permission to check
             obj: A Team or Environment object. Any other type will return False.
 
         Returns:
@@ -38,7 +38,7 @@ class CoreBackend(BaseBackend):
             return True
         else:
             # Allow the perm to be either the enum or its value
-            if isinstance(perm, Permissions):
+            if isinstance(perm, Permission):
                 perm = perm.value
 
             return perm in self._user_permissions_for_object(user, obj)

--- a/functionary/core/models/user_role.py
+++ b/functionary/core/models/user_role.py
@@ -2,9 +2,9 @@
 from django.conf import settings
 from django.db import models
 
-from core.auth import Roles
+from core.auth import Role
 
-ROLE_CHOICES = [(role.name, role.value) for role in Roles]
+ROLE_CHOICES = [(role.name, role.value) for role in Role]
 
 
 class UserRole(models.Model):


### PR DESCRIPTION
This PR fixes the Enum names in core.auth to be singular rather than plural, to better follow standard conventions.