### PR TITLE
#34 - Environment ViewSets

### DIFF
--- a/functionary/README.md
+++ b/functionary/README.md
@@ -53,6 +53,15 @@ location using the environment variables described earlier.
 started working on Functionary. Instructions for general users will be added as
 the project matures.
 
+### Python Requirements
+
+Functionary is being developed with containers being the primary target for
+deployment. As such, the intention is to officially support only the latest
+minor version of python (e.g. The latest 3.X). Be sure to keep this in mind if
+you are intending to run the application locally while developing.
+
+### Django Setup
+
 Install the requirements like so:
 
 ```shell

--- a/functionary/builder/api/v1/views/build.py
+++ b/functionary/builder/api/v1/views/build.py
@@ -1,12 +1,12 @@
 from rest_framework import permissions
-from rest_framework.viewsets import ModelViewSet
 
 from builder.models import Build
+from core.api.viewsets import EnvironmentReadOnlyModelViewSet
 
 from ..serializers import BuildSerializer
 
 
-class BuildViewSet(ModelViewSet):
+class BuildViewSet(EnvironmentReadOnlyModelViewSet):
     queryset = Build.objects.all()
     serializer_class = BuildSerializer
 

--- a/functionary/core/api/mixins.py
+++ b/functionary/core/api/mixins.py
@@ -1,3 +1,5 @@
+from functools import cache
+
 from django.core.exceptions import ValidationError
 from drf_spectacular.utils import OpenApiParameter
 
@@ -29,6 +31,7 @@ class EnvironmentViewMixin:
         ),
     ]
 
+    @cache
     def get_environment(self) -> Environment:
         """Retrieve the Environment object that corresponds to either the environment
         with id X-Environment-Id or the default environment for the team with id

--- a/functionary/core/api/v1/views/function.py
+++ b/functionary/core/api/v1/views/function.py
@@ -1,12 +1,13 @@
 from rest_framework import permissions
-from rest_framework.viewsets import ModelViewSet
 
+from core.api.viewsets import EnvironmentReadOnlyModelViewSet
 from core.models import Function
 
 from ..serializers import FunctionSerializer
 
 
-class FunctionViewSet(ModelViewSet):
+class FunctionViewSet(EnvironmentReadOnlyModelViewSet):
     queryset = Function.objects.all()
     serializer_class = FunctionSerializer
     permission_classes = [permissions.IsAuthenticated]
+    environment_through_field = "package"

--- a/functionary/core/api/v1/views/package.py
+++ b/functionary/core/api/v1/views/package.py
@@ -1,12 +1,12 @@
 from rest_framework import permissions
-from rest_framework.viewsets import ModelViewSet
 
+from core.api.viewsets import EnvironmentModelViewSet
 from core.models import Package
 
 from ..serializers import PackageSerializer
 
 
-class PackageViewSet(ModelViewSet):
+class PackageViewSet(EnvironmentModelViewSet):
     queryset = Package.objects.all()
     serializer_class = PackageSerializer
     permission_classes = [permissions.IsAuthenticated]

--- a/functionary/core/api/v1/views/team.py
+++ b/functionary/core/api/v1/views/team.py
@@ -1,12 +1,12 @@
 from rest_framework import permissions
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from core.models import Team
 
 from ..serializers import TeamSerializer
 
 
-class TeamViewSet(ModelViewSet):
+class TeamViewSet(ReadOnlyModelViewSet):
     queryset = Team.objects.all()
     serializer_class = TeamSerializer
     permission_classes = [permissions.IsAuthenticated]

--- a/functionary/core/api/v1/views/user.py
+++ b/functionary/core/api/v1/views/user.py
@@ -1,12 +1,12 @@
 from rest_framework import permissions
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from core.models import User
 
 from ..serializers import UserSerializer
 
 
-class UserViewSet(ModelViewSet):
+class UserViewSet(ReadOnlyModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
     permission_classes = [permissions.IsAuthenticated]

--- a/functionary/core/api/viewsets.py
+++ b/functionary/core/api/viewsets.py
@@ -1,0 +1,86 @@
+from typing import Optional
+
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from rest_framework import mixins
+from rest_framework.viewsets import GenericViewSet
+
+from .mixins import EnvironmentViewMixin
+
+
+class EnvironmentGenericViewSet(EnvironmentViewMixin, GenericViewSet):
+    """This viewset is intended for use in place of GenericViewSets where access
+    control and queryset filtering should be done based on the appropriate environment
+    for the request. The X-Environment-Id and X-Team-Id headers are to used to
+    determine the environment.
+
+    For model based ViewSets with a queryset, the queryset must be filterable by an
+    environment, either directly or through another field on the model. If the
+    environment is defined through another field, declare that in the ViewSet class
+    using:
+
+        environment_through_field = "somefield"
+    """
+
+    environment_through_field: Optional[str] = None
+
+    def get_queryset(self):
+        """Filters the ViewSet queryset down to the appropriate objects based on the
+        request environment context."""
+
+        if self.environment_through_field:
+            environment_field = f"{self.environment_through_field}__environment"
+        else:
+            environment_field = "environment"
+
+        return (
+            super().get_queryset().filter(**{environment_field: self.get_environment()})
+        )
+
+
+@extend_schema_view(
+    create=extend_schema(parameters=EnvironmentViewMixin.header_parameters),
+    retrieve=extend_schema(parameters=EnvironmentViewMixin.header_parameters),
+    list=extend_schema(parameters=EnvironmentViewMixin.header_parameters),
+    update=extend_schema(parameters=EnvironmentViewMixin.header_parameters),
+    destroy=extend_schema(parameters=EnvironmentViewMixin.header_parameters),
+)
+class EnvironmentModelViewSet(
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    mixins.ListModelMixin,
+    EnvironmentGenericViewSet,
+):
+    """Replacement for ModelViewSet that provides queryset filtering and access
+    control based on the requesting user's environment permissions.
+
+    The ViewSet's queryset must be filterable by an environment, either directly or
+    through another field on the model. If the environment is defined through another
+    field, declare that in the ViewSet class using:
+
+        environment_through_field = "somefield"
+    """
+
+    pass
+
+
+@extend_schema_view(
+    list=extend_schema(parameters=EnvironmentViewMixin.header_parameters),
+    retrieve=extend_schema(parameters=EnvironmentViewMixin.header_parameters),
+)
+class EnvironmentReadOnlyModelViewSet(
+    mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    EnvironmentGenericViewSet,
+):
+    """Replacement for ReadOnlyModelViewSet that provides queryset filtering and access
+    control based on the requesting user's environment permissions.
+
+    The ViewSet's queryset must be filterable by an environment, either directly or
+    through another field on the model. If the environment is defined through another
+    field, declare that in the ViewSet class using:
+
+        environment_through_field = "somefield"
+    """
+
+    pass


### PR DESCRIPTION
Closes #34 

This PR adds `EnvironmentModelViewSet` and `EnvironmentReadOnlyModelViewSet`, which are intended to be used in place of the DRF `ModelViewSet` and `ReadOnlyModelViewSet` in situations where the ViewSet's queryset should be filtered to objects belonging to the request's environment context.  The following functionality is provided:

* The queryset is automatically filtered to the correct objects for the environment.
* If the relationship to an environment is indirect (i.e. The `Function` model has an environment through it's associated package), that can be defined via the `environment_through_field` attribute.
* The environment and team header parameters are included so that they do not have to be explicitly added to ViewSets building off of these new ones.

## Test Instructions
* Create packages, functions, and builds for two separate environments.
* Query the respective endpoints.  In each case you should only see results that are for the environment ID (or default environment for the team id) that you supplied via the header parameter.  Before these changes you would always see all results, regardless of the provided environment.