### PR TITLE
#37 - Environment based permission class for views

### DIFF
--- a/functionary/builder/api/v1/views/build.py
+++ b/functionary/builder/api/v1/views/build.py
@@ -1,14 +1,14 @@
-from rest_framework import permissions
-
 from builder.models import Build
+from core.api.permissions import HasEnvironmentPermissionForAction
 from core.api.viewsets import EnvironmentReadOnlyModelViewSet
 
 from ..serializers import BuildSerializer
 
 
 class BuildViewSet(EnvironmentReadOnlyModelViewSet):
+    """View the status of package builds"""
+
     queryset = Build.objects.all()
     serializer_class = BuildSerializer
-
-    # TODO: Proper permissions
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [HasEnvironmentPermissionForAction]
+    permissioned_model = "Package"

--- a/functionary/builder/api/v1/views/publish.py
+++ b/functionary/builder/api/v1/views/publish.py
@@ -1,5 +1,4 @@
 from drf_spectacular.utils import extend_schema
-from rest_framework import permissions
 from rest_framework.exceptions import ParseError
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
@@ -9,6 +8,7 @@ from builder.exceptions import InvalidPackage
 from builder.utils import extract_package_definition, initiate_build
 from core.api.exceptions import BadRequest
 from core.api.mixins import EnvironmentViewMixin
+from core.api.permissions import HasEnvironmentPermissionForAction
 
 from ..serializers import BuildSerializer, PackageDefinitionWithVersionSerializer
 
@@ -16,10 +16,9 @@ from ..serializers import BuildSerializer, PackageDefinitionWithVersionSerialize
 class PublishView(APIView, EnvironmentViewMixin):
     """View for submitting a package to be built and published."""
 
-    # TODO: Authentication and permissions
-    permission_classes = [permissions.IsAuthenticated]
-
     parser_classes = [MultiPartParser]
+    permission_classes = [HasEnvironmentPermissionForAction]
+    permissioned_model = "Package"
 
     # TODO: Add reference to package description YAML documentation once it exists
     @extend_schema(

--- a/functionary/core/api/permissions.py
+++ b/functionary/core/api/permissions.py
@@ -1,0 +1,61 @@
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.permissions import BasePermission
+
+from core.auth import Permission
+
+
+class HasEnvironmentPermissionForAction(BasePermission):
+    """Custom permission class that checks if the request user has the supplied
+    permission for the request team or environment.
+
+    This permission class should only be used in ViewSets that build off of
+    EnvironmentViewMixin. It assumes the presence of verify_user_permission on the view.
+
+    The permission checked is based off of the model of the view's queryset. If the view
+    has no queryset, or an alternative model should be used, the name of the model
+    can be supplied by settings the `permissioned_model` attribute on the ViewSet class.
+    For example:
+
+        permissioned_model = "Package"
+    """
+
+    method_action_map = {
+        "POST": "CREATE",
+        "GET": "READ",
+        "OPTIONS": "READ",
+        "HEAD": "READ",
+        "PUT": "UPDATE",
+        "PATCH": "UPDATE",
+        "DELETE": "DELETE",
+    }
+
+    def _get_permission_for_request(self, request, view) -> str:
+        """Construct the permission required for the request"""
+        model_name = (
+            getattr(view, "permissioned_model", None) or view.queryset.model.__name__
+        ).upper()
+        action = self.method_action_map.get(request.method)
+
+        return getattr(Permission, f"{model_name}_{action}")
+
+    def has_permission(self, request, view) -> bool:
+        """Checks if the requesting user has the permission necessary to perform the
+        requested action.
+
+        Args:
+            request: The django request object containing the user and request method
+            view: A drf view class inheriting from EnvironmentViewMixin
+
+        Returns:
+            True if access should be granted. False otherwise.
+        """
+        permission = self._get_permission_for_request(request, view)
+
+        try:
+            view.verify_user_permission(permission)
+        except PermissionDenied:
+            # This should return False rather than raise as to allow for use in
+            # conjunction with other permissions classes.
+            return False
+
+        return True

--- a/functionary/core/api/v1/views/execute.py
+++ b/functionary/core/api/v1/views/execute.py
@@ -2,7 +2,7 @@ import logging
 
 import jsonschema
 from drf_spectacular.utils import extend_schema
-from rest_framework import permissions, status
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -21,8 +21,6 @@ class ExecuteView(APIView, EnvironmentViewMixin):
     """View for executing a function with specified parameters."""
 
     serializer_class = ExecuteSerializer
-    # TODO: Proper permissions
-    permission_classes = [permissions.IsAuthenticated]
 
     @extend_schema(
         description=("Execute a Function"),

--- a/functionary/core/api/v1/views/function.py
+++ b/functionary/core/api/v1/views/function.py
@@ -1,5 +1,4 @@
-from rest_framework import permissions
-
+from core.api.permissions import HasEnvironmentPermissionForAction
 from core.api.viewsets import EnvironmentReadOnlyModelViewSet
 from core.models import Function
 
@@ -7,7 +6,9 @@ from ..serializers import FunctionSerializer
 
 
 class FunctionViewSet(EnvironmentReadOnlyModelViewSet):
+    """View functions across all known packages"""
+
     queryset = Function.objects.all()
     serializer_class = FunctionSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [HasEnvironmentPermissionForAction]
     environment_through_field = "package"

--- a/functionary/core/api/v1/views/package.py
+++ b/functionary/core/api/v1/views/package.py
@@ -1,5 +1,4 @@
-from rest_framework import permissions
-
+from core.api.permissions import HasEnvironmentPermissionForAction
 from core.api.viewsets import EnvironmentModelViewSet
 from core.models import Package
 
@@ -7,6 +6,8 @@ from ..serializers import PackageSerializer
 
 
 class PackageViewSet(EnvironmentModelViewSet):
+    """View for retrieving and updating packages"""
+
     queryset = Package.objects.all()
     serializer_class = PackageSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [HasEnvironmentPermissionForAction]

--- a/functionary/core/api/v1/views/team.py
+++ b/functionary/core/api/v1/views/team.py
@@ -1,4 +1,3 @@
-from rest_framework import permissions
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from core.models import Team
@@ -9,4 +8,3 @@ from ..serializers import TeamSerializer
 class TeamViewSet(ReadOnlyModelViewSet):
     queryset = Team.objects.all()
     serializer_class = TeamSerializer
-    permission_classes = [permissions.IsAuthenticated]

--- a/functionary/core/api/v1/views/user.py
+++ b/functionary/core/api/v1/views/user.py
@@ -1,4 +1,3 @@
-from rest_framework import permissions
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from core.models import User
@@ -9,4 +8,3 @@ from ..serializers import UserSerializer
 class UserViewSet(ReadOnlyModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
-    permission_classes = [permissions.IsAuthenticated]

--- a/functionary/functionary/settings/rest_framework_.py
+++ b/functionary/functionary/settings/rest_framework_.py
@@ -8,6 +8,9 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.BasicAuthentication",
     ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+    ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "PAGE_SIZE": 25,
 }


### PR DESCRIPTION
Closes #37 

This PR does the following:

* Sets the drf `DEFAULT_PERMISSION_CLASSES` to `isAuthenticated`.  Any views that intend to use that as their permission class no longer have it explicitly defined.
* Adds a `HasEnvironmentPermissionForAction` permission class for use on viewsets that inherit build off of the `EnvironmentViewMixin` mixin in some way.  This class determines the permission needed for the request and then grants or denies access based on the user's permissions.
* The `ExecuteView` remains untouched for now.  Although it falls into the same category as `PublishView`, that is going to change soon as we move that logic over to a `TaskViewSet`.  The permissions enforcement will be added then.

## Testing Instructions

* Create a non-admin user.  Do not assign it any user roles.
* Hitting the functions, builds, or packages endpoints as that user should result in a 403.
* Assign the user the read only role for some environment.
* Now doing a GET against endpoints should work, but trying to POST (such as the /publish endpoint) should still 403.
* Feel free to play around with other things.