### PR TITLE
#28: CLI - Add env set and list

### DIFF
--- a/cli/functionary/environment.py
+++ b/cli/functionary/environment.py
@@ -1,0 +1,98 @@
+import json
+
+import click
+import requests
+
+from .config import get_config_value, save_config_value
+
+
+def get_environment_list():
+    """
+    Helper function to get the environment list from host
+
+    Args:
+        None
+
+    Returns:
+        None
+
+    Raises:
+        ClickException if bad get request
+    """
+    token = get_config_value("token")
+    teams_url = get_config_value("host") + "/api/v1/teams"
+    header = {"Authorization": f"Token {token}"}
+    response = requests.get(teams_url, headers=header)
+
+    if response.ok:
+        data = json.loads(response.text).get("results")
+
+        env_list = []
+        for team in data:
+            for env_set in team.get("environments"):
+                env_list.append(env_set)
+        return env_list
+    else:
+        raise click.ClickException(
+            f"Failed to get environment list: {response.status_code}\n"
+            f"Response: {response.text}"
+        )
+
+
+@click.group("environment")
+@click.pass_context
+def environment_cmd(ctx):
+    pass
+
+
+@environment_cmd.command()
+@click.pass_context
+def set(ctx):
+    """
+    Command to set the environment id based on user input
+
+    Args:
+        Ctx: The click context
+
+    Returns:
+        None
+
+    Raises:
+        ClickException if bad environment number
+    """
+    env_list = get_environment_list()
+    index = 1
+    click.echo("Available Environments:")
+    for item in env_list:
+        click.echo(f"    {index}) {item.get('name')}")
+        index += 1
+    user_choice = click.prompt("Select environment", type=int)
+    try:
+        value = env_list[user_choice - 1]
+    except IndexError:
+        raise click.ClickException("Environment number chosen is not valid")
+    click.echo(f"Active environment is now {value.get('name')}")
+    save_config_value("current_environment", json.dumps(value))
+
+
+@environment_cmd.command()
+@click.pass_context
+def list(ctx):
+    """
+    Command to list all possible environments
+
+    Args:
+        Ctx: The click context
+
+    Returns:
+        None
+    """
+    env_list = get_environment_list()
+    current_env_id = json.loads(get_config_value("current_environment")).get("id")
+    for item in env_list:
+        name = item.get("name")
+        active = "  "
+        if current_env_id == item.get("id"):
+            active = "* "
+
+        click.echo(f"{active}{name}")

--- a/cli/functionary/environment.py
+++ b/cli/functionary/environment.py
@@ -40,7 +40,7 @@ def _get_environment_list():
 @click.pass_context
 def environment_cmd(ctx):
     """
-    Click group to associate all environment related commands with
+    List or set environments
     """
     pass
 
@@ -55,7 +55,7 @@ def set(ctx):
     index = 1
     click.echo("Available Environments:")
     for item in env_list:
-        click.echo(f"    {index}) {item.get('name')} - {item.get('team')}")
+        click.echo(f"    {index}) {item.get('team')} - {item.get('name')}")
         index += 1
     user_choice = click.prompt("Select environment", type=int)
     try:
@@ -86,4 +86,4 @@ def list(ctx):
         if current_env_id == item.get("id"):
             active = "* "
 
-        click.echo(f"{active}{name} - {team}")
+        click.echo(f"{active}{team} - {name}")

--- a/cli/functionary/functionary.py
+++ b/cli/functionary/functionary.py
@@ -1,5 +1,6 @@
 import click
 
+from .environment import environment_cmd
 from .login import login_cmd
 from .package import package_cmd
 
@@ -11,3 +12,4 @@ def cli():
 
 cli.add_command(login_cmd)
 cli.add_command(package_cmd)
+cli.add_command(environment_cmd)

--- a/cli/functionary/package.py
+++ b/cli/functionary/package.py
@@ -1,4 +1,4 @@
-import os
+import json
 import pathlib
 import shutil
 import tarfile
@@ -25,11 +25,6 @@ def generateYaml(output_dir: str, name: str, language: str):
     path = pathlib.Path(output_dir).resolve() / name / f"{name}.yaml"
     with path.open(mode="w"):
         path.write_text(yaml.dump(metadata))
-
-
-def get_environment_id():
-    environment_id = os.environ.get("FUNCTIONARY_ENVIRONMENT")
-    return environment_id
 
 
 @click.group("package")
@@ -91,7 +86,7 @@ def publish(ctx, path):
     # publish should http the tar to a server, wait for return
     upload_file = open(tarfile_name, "rb")
     upload_response = None
-    environment_id = get_environment_id()
+    environment_id = json.loads(get_config_value("current_environment")).get("id")
     headers = {
         "Authorization": f"Token {token}",
         "X-Environment-ID": f"{environment_id}",


### PR DESCRIPTION
Closes #28 

Created new environment.py file that has a get and a set command, storing the current environment in the config file. Changed publish to use the new config file value instead of us exporting through the command line.

Original issue had wondered about creating an alias so that environment and env would go to the same list of commands. I did a little searching and it doesn't look like Click supports this out of the box, but there do seem to be a few libraries that support it that we could import (like this one for example: [https://pypi.org/project/click-aliases/](url)