### PR TITLE
#41 - Filter team endpoint based on user roles

### DIFF
--- a/functionary/core/api/v1/serializers/team.py
+++ b/functionary/core/api/v1/serializers/team.py
@@ -15,8 +15,30 @@ class TeamEnvironmentSerializer(serializers.ModelSerializer):
 class TeamSerializer(serializers.ModelSerializer):
     """Basic serializer for the Team model"""
 
-    environments = TeamEnvironmentSerializer(many=True)
+    environments = serializers.SerializerMethodField()
 
     class Meta:
         model = Team
         fields = ["id", "name", "environments"]
+
+    def get_environments(self, team):
+        """In the context of a request, filters the list of environments down to
+        those of the requesting user."""
+
+        request = self.context.get("request")
+
+        # If we are using the serializer outside of the context of a request, do not
+        # filter the environments.
+        #
+        # In the context of a request, if the user is a superuser or has a role on the
+        # team itself we do not need to filter the environments.
+        if (
+            request is None
+            or request.user.is_superuser
+            or team.user_roles.filter(user=request.user).exists()
+        ):
+            environments = team.environments.all()
+        else:
+            environments = team.environments.filter(user_roles__user=request.user)
+
+        return TeamEnvironmentSerializer(environments, many=True).data

--- a/functionary/core/api/v1/views/team.py
+++ b/functionary/core/api/v1/views/team.py
@@ -8,3 +8,15 @@ from ..serializers import TeamSerializer
 class TeamViewSet(ReadOnlyModelViewSet):
     queryset = Team.objects.all()
     serializer_class = TeamSerializer
+
+    def get_queryset(self):
+        """Filter Team queryset down to those to which the requesting user is assigned
+        a role, either directly or through one of the Team's environments."""
+
+        if self.request.user.is_superuser:
+            return self.queryset
+        else:
+            return (
+                self.queryset.filter(environments__user_roles__user=self.request.user)
+                | self.queryset.filter(user_roles__user=self.request.user)
+            ).distinct()

--- a/functionary/core/models/user_role.py
+++ b/functionary/core/models/user_role.py
@@ -36,9 +36,7 @@ class TeamUserRole(UserRole):
 
     class Meta:
         constraints = [
-            models.UniqueConstraint(
-                fields=["user", "team", "role"], name="unique_user_team_role"
-            )
+            models.UniqueConstraint(fields=["user", "team"], name="unique_user_team")
         ]
 
     def __str__(self):
@@ -64,8 +62,8 @@ class EnvironmentUserRole(UserRole):
     class Meta:
         constraints = [
             models.UniqueConstraint(
-                fields=["user", "environment", "role"],
-                name="unique_user_environment_role",
+                fields=["user", "environment"],
+                name="unique_user_environment",
             )
         ]
 


### PR DESCRIPTION
Closes #41 

This PR adds filtering on the `/api/v1/teams` endpoint to only show the teams and environments to which a user belongs.  The behavior is now this:

* If the user is a superuser, all teams and environments will be shown.
* If the user has a role on a team, that team and all of its environments will be shown.
* If the user has a role on an environment, that environment's team will shown, but only the environments that the user has a role on will be shown for that team.

There's also a fix to the unique constraint on user roles.  The intent was that a user should have only a single role assigned per team or environment.  That is now properly enforced.