### PR TITLE
Issue 47: Adding buildstatus and table output

### DIFF
--- a/cli/functionary/client.py
+++ b/cli/functionary/client.py
@@ -18,7 +18,7 @@ def get(endpoint):
 
     """
     response = _send_request(endpoint, "get")
-    return json.loads(response.text).get("results")
+    return json.loads(response.text)
 
 
 def post(endpoint, data=None, files=None):

--- a/cli/functionary/client.py
+++ b/cli/functionary/client.py
@@ -18,7 +18,12 @@ def get(endpoint):
 
     """
     response = _send_request(endpoint, "get")
-    return json.loads(response.text)
+    response_data = json.loads(response.text)
+
+    if "results" in response_data:
+        return response_data["results"]
+    else:
+        return response_data
 
 
 def post(endpoint, data=None, files=None):

--- a/cli/functionary/environment.py
+++ b/cli/functionary/environment.py
@@ -1,4 +1,6 @@
 import click
+from rich.console import Console
+from rich.text import Text
 
 from .client import get
 from .config import get_config_value, save_config_value
@@ -8,7 +10,7 @@ def _get_environment_list():
     """
     Helper function to get the environment list from host
     """
-    teams = get("teams")
+    teams = get("teams").get("results")
 
     env_list = []
     for team in teams:
@@ -59,10 +61,13 @@ def list(ctx):
     env_list = _get_environment_list()
     current_env_id = get_config_value("current_environment_id")
     for item in env_list:
+        text = Text()
+        console = Console()
         name = item.get("name")
         team = item.get("team")
         active = "  "
         if current_env_id == item.get("id"):
             active = "* "
-
-        click.echo(f"{active}{team} - {name}")
+        text.append(f"{active}", style="bold red")
+        text.append(f"{team} - {name}")
+        console.print(text)

--- a/cli/functionary/environment.py
+++ b/cli/functionary/environment.py
@@ -10,7 +10,7 @@ def _get_environment_list():
     """
     Helper function to get the environment list from host
     """
-    teams = get("teams").get("results")
+    teams = get("teams")
 
     env_list = []
     for team in teams:

--- a/cli/functionary/package.py
+++ b/cli/functionary/package.py
@@ -4,8 +4,10 @@ import tarfile
 
 import click
 import yaml
+from rich.console import Console
+from rich.table import Table
 
-from .client import post
+from .client import get, post
 from .config import get_config_value
 
 
@@ -84,3 +86,43 @@ def publish(ctx, path):
         response = post("publish", files={"package_contents": upload_file})
         id = response["id"]
         click.echo(f"Package upload complete\nBuild id: {id}")
+
+
+@package_cmd.command()
+@click.pass_context
+@click.option("--id")
+def buildstatus(ctx, id):
+    """
+    View status for all builds, or build with specific id
+    """
+    if id:
+        results = get(f"builds/{id}")
+        _format_results([results], title=f"Build: {id}")
+    else:
+        results = get("builds").get("results")
+        _format_results(results, title="Build Status")
+
+
+def _format_results(results, title=""):
+    """
+    Helper function to organize table results using Rich
+
+    Args:
+        results: Results to format as a List
+        title: Optional table title as a String
+
+    Returns:
+        None
+    """
+    table = Table(title=title, width=170)
+    console = Console()
+    first_row = True
+    for item in results:
+        list = []
+        for key in item:
+            if first_row:
+                table.add_column(key.capitalize())
+            list.append(str(item[key]))
+        table.add_row(*list)
+        first_row = False
+    console.print(table)

--- a/cli/functionary/package.py
+++ b/cli/functionary/package.py
@@ -4,11 +4,10 @@ import tarfile
 
 import click
 import yaml
-from rich.console import Console
-from rich.table import Table
 
 from .client import get, post
 from .config import get_config_value
+from .utils import format_results
 
 
 def create_languages() -> list[str]:
@@ -90,39 +89,14 @@ def publish(ctx, path):
 
 @package_cmd.command()
 @click.pass_context
-@click.option("--id")
+@click.option("--id", help="check the status of a specific build with given id")
 def buildstatus(ctx, id):
     """
     View status for all builds, or build with specific id
     """
     if id:
         results = get(f"builds/{id}")
-        _format_results([results], title=f"Build: {id}")
+        format_results([results], title=f"Build: {id}")
     else:
-        results = get("builds").get("results")
-        _format_results(results, title="Build Status")
-
-
-def _format_results(results, title=""):
-    """
-    Helper function to organize table results using Rich
-
-    Args:
-        results: Results to format as a List
-        title: Optional table title as a String
-
-    Returns:
-        None
-    """
-    table = Table(title=title, width=170)
-    console = Console()
-    first_row = True
-    for item in results:
-        list = []
-        for key in item:
-            if first_row:
-                table.add_column(key.capitalize())
-            list.append(str(item[key]))
-        table.add_row(*list)
-        first_row = False
-    console.print(table)
+        results = get("builds")
+        format_results(results, title="Build Status")

--- a/cli/functionary/utils.py
+++ b/cli/functionary/utils.py
@@ -1,0 +1,31 @@
+from rich.console import Console
+from rich.table import Table
+
+
+def format_results(results, title=""):
+    """
+    Helper function to organize table results using Rich
+
+    Args:
+        results: Results to format as a List
+        title: Optional table title as a String
+
+    Returns:
+        None
+    """
+    table = Table(title=title)
+    console = Console()
+    first_row = True
+    EXCLUDED_FIELDS = ["environment"]
+
+    for item in results:
+        row_data = []
+        for key, value in item.items():
+            if key in EXCLUDED_FIELDS:
+                continue
+            if first_row:
+                table.add_column(key.capitalize())
+            row_data.append(str(value) if value else None)
+        table.add_row(*row_data)
+        first_row = False
+    console.print(table)

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -10,13 +10,19 @@ charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via functionary (setup.py)
+commonmark==0.9.1
+    # via rich
 idna==3.3
     # via requests
+pygments==2.13.0
+    # via rich
 python-dotenv==0.20.0
     # via functionary (setup.py)
 pyyaml==6.0
     # via functionary (setup.py)
 requests==2.28.1
+    # via functionary (setup.py)
+rich==12.5.1
     # via functionary (setup.py)
 urllib3==1.26.12
     # via requests

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -15,6 +15,7 @@ setup(
     install_requires=[
         "Click>=8.0.0",
         "requests>=2.0.0",
+        "rich>=12.5.0",
         "pyyaml>=6.0",
         "python-dotenv>=0.20.0",
     ],


### PR DESCRIPTION
Closes #47 

I have added a buildstatus command into package.py. This uses the rich library (which you'd need to install with pip install rich) to turn API data into a nice table. I've written a helper function called _format_results to turn a list of dictionaries into a Rich table. That function currently lives in package.py but it could live somewhere else if we'd rather.

Also, I changed environment list to have the active environment marked in red. Could change that color if needed.