### PR TITLE
Issue 50: Add way to view packages and their functions

### DIFF
--- a/cli/functionary/package.py
+++ b/cli/functionary/package.py
@@ -96,7 +96,61 @@ def buildstatus(ctx, id):
     """
     if id:
         results = get(f"builds/{id}")
-        format_results([results], title=f"Build: {id}")
+        format_results([results], title=f"Build: {id}", excluded_fields=["environment"])
     else:
         results = get("builds")
-        format_results(results, title="Build Status")
+        format_results(results, title="Build Status", excluded_fields=["environment"])
+
+
+@package_cmd.command()
+@click.pass_context
+@click.option("--id", help="view a specific package with the given id")
+def view(ctx, id):
+    """
+    View all current packages and their functions
+    """
+    packages = get("packages")
+    functions = get("functions")
+    if id:
+        name = ""
+        description = ""
+        found = False
+        for package in packages:
+            if package["id"] == id:
+                name = package["name"]
+                description = package["description"]
+                found = True
+        if found:
+            associated_functions = []
+            for function in functions:
+                if function["package"] == id:
+                    function_dict = {}
+                    function_dict["Function Name"] = function["name"]
+                    function_dict["Display Name"] = function["display_name"]
+                    function_dict["Description"] = function["description"]
+                    associated_functions.append(function_dict)
+            format_results(
+                associated_functions,
+                title=f"{name}\n {description}",
+            )
+        else:
+            click.echo(f"Package with id {id} not found")
+    else:
+        for i in range(0, len(packages)):
+            package = packages[i]
+            name = package["name"]
+            description = package["description"]
+            associated_functions = []
+            for function in functions:
+                if function["package"] == package["id"]:
+                    function_dict = {}
+                    function_dict["Function Name"] = function["name"]
+                    function_dict["Display Name"] = function["display_name"]
+                    function_dict["Description"] = function["description"]
+                    associated_functions.append(function_dict)
+            format_results(
+                associated_functions,
+                title=f"{name} \n {description}",
+            )
+            if i != len(packages) - 1:
+                click.echo("\n")

--- a/cli/functionary/utils.py
+++ b/cli/functionary/utils.py
@@ -2,7 +2,7 @@ from rich.console import Console
 from rich.table import Table
 
 
-def format_results(results, title=""):
+def format_results(results, title="", caption=None, excluded_fields=[]):
     """
     Helper function to organize table results using Rich
 
@@ -13,15 +13,14 @@ def format_results(results, title=""):
     Returns:
         None
     """
-    table = Table(title=title)
+    table = Table(title=title, caption=caption, show_lines=True)
     console = Console()
     first_row = True
-    EXCLUDED_FIELDS = ["environment"]
 
     for item in results:
         row_data = []
         for key, value in item.items():
-            if key in EXCLUDED_FIELDS:
+            if key in excluded_fields:
                 continue
             if first_row:
                 table.add_column(key.capitalize())


### PR DESCRIPTION
Closes #50 

Here's one possible way we could go about viewing packages + functions. Right now in the basic view command, every function gets its own table with all its different functions and some relevant information (I could add things like schema back in if we wanted them).

Also, since package buildstatus has an option to query builds by id, I did add in an optional argument to query by package id so we just spit out one table. I'm not entirely sure if we want it, but I could see it being helpful if you just want information about one particular package.