### PR TITLE
Task Execution

### DIFF
--- a/functionary/README.md
+++ b/functionary/README.md
@@ -6,6 +6,7 @@
 
 To run the various components of Functionary you'll first need the following:
 
+- RabbitMQ
 - Redis
 - A private container registry
 
@@ -23,6 +24,8 @@ default, it will be assumed that these services are accessible via localhost on
 their default ports. If they are located elsewhere, you can configure that via
 environment variables:
 
+- RABBITMQ_HOST
+- RABBITMQ_PORT
 - REDIS_HOST
 - REDIS_PORT
 - REGISTRY_HOST
@@ -96,6 +99,26 @@ DEBUG=TRUE DJANGO_SECRET_KEY=supersecret ./manage.py runserver 8000
 
 The `DJANGO_SECRET_KEY` is arbitrary and the `8000` at the end is the port
 number to listen on. It can be freely changed to anything.
+
+## Start the main worker
+
+The worker process handles communications between the main django process and
+any external services, such as the runners. Actions such as creating a Task to
+execute a function result in a response being returned right away, but the
+actual work is scheduled to happen asynchronously via a worker process. To start
+the worker process:
+
+```shell
+LOG_LEVEL=INFO \
+RABBITMQ_USER=someuser \
+RABBITMQ_PASSWORD=greatpassword \
+./manage.py run_worker
+```
+
+Be sure to set the username and password values as appropriate for your
+environment. If you are using the included
+[docker-compose.yml](../docker/docker-compose.yml), you can use the values of
+`RABBITMQ_DEFAULT_USER` and `RABBITMQ_DEFAULTPASS`.
 
 ## Start the build worker
 

--- a/functionary/core/celery.py
+++ b/functionary/core/celery.py
@@ -1,5 +1,5 @@
 from celery import Celery
 
-app = Celery("builder")
+app = Celery("core", include=["core.utils.tasking"])
 app.config_from_object("django.conf:settings", namespace="CELERY")
-app.conf.task_default_queue = "builder"
+app.conf.task_default_queue = "core"

--- a/functionary/core/management/commands/run_worker.py
+++ b/functionary/core/management/commands/run_worker.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+
+from core.celery import app
+from core.utils.messaging import initialize_messaging
+
+
+# TODO: Make various things configurable. Concurrency, etc.
+class Command(BaseCommand):
+    help = "Run the task workers"
+
+    def handle(self, *args, **options):
+        # TODO: Once there's a proper runner registration process, the need for this
+        #       largely goes away and it can potentially be moved to a mangement
+        #       command.
+        initialize_messaging()
+
+        worker = app.Worker()
+        worker.start()

--- a/functionary/core/models/__init__.py
+++ b/functionary/core/models/__init__.py
@@ -1,5 +1,6 @@
 from .environment import Environment  # noqa
 from .function import Function  # noqa
+from .mixins import ModelSaveHookMixin  # noqa
 from .package import Package  # noqa
 from .task import Task  # noqa
 from .team import Team  # noqa

--- a/functionary/core/models/mixins.py
+++ b/functionary/core/models/mixins.py
@@ -1,0 +1,54 @@
+from django.db import transaction
+
+
+class ModelSaveHookMixin:
+    """This mixin provides access to hooks for actions to take place before or after
+    save and creation. To use it, simply include this mixin and then override any of
+    the following methods:
+
+        pre_create
+        pre_save
+        post_create
+        post_save
+
+    These methods are run, in that order, inside of a transaction during the model's
+    save() call. The pre_create and post_create are only run on newly created instances
+    and not any subsequent updates.  If an exception is raised at any point in any of
+    the methods or the save() itself, all database activity will be rolled back.
+    """
+
+    def pre_create(self):
+        """Actions to run before create"""
+        pass
+
+    def post_create(self):
+        """Actions to run after create"""
+        pass
+
+    def pre_save(self):
+        """Actions to run before save"""
+        pass
+
+    def post_save(self):
+        """Actions to run after save"""
+        pass
+
+    def save(self, *args, **kwargs):
+        """Custom save that calls the pre and post save hooks inside of a
+        transaction"""
+        creating = self._state.adding
+
+        with transaction.atomic():
+            if creating:
+                self.pre_create()
+
+            self.pre_save()
+
+            super().save(*args, **kwargs)
+
+            if creating:
+                self.post_create()
+
+            self.post_save()
+
+        return self

--- a/functionary/core/models/task.py
+++ b/functionary/core/models/task.py
@@ -6,10 +6,10 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 
-from core.models import Environment, Function
+from core.models import Environment, Function, ModelSaveHookMixin
 
 
-class Task(models.Model):
+class Task(ModelSaveHookMixin, models.Model):
     """A Task is an individual execution of a function
 
     This model should always be queried with environment as one of the filter
@@ -91,3 +91,9 @@ class Task(models.Model):
         """Model instance validation and attribute cleanup"""
         self._clean_environment()
         self._clean_parameters()
+
+    def post_create(self):
+        """Post create hooks"""
+        from core.utils.tasking import publish_task
+
+        publish_task.delay(self.id)

--- a/functionary/core/models/team.py
+++ b/functionary/core/models/team.py
@@ -2,10 +2,12 @@
 import uuid
 
 from django.apps import apps
-from django.db import models, transaction
+from django.db import models
+
+from core.models import ModelSaveHookMixin
 
 
-class Team(models.Model):
+class Team(ModelSaveHookMixin, models.Model):
     """Namespace that teams of users work under
 
     Attributes:
@@ -19,17 +21,7 @@ class Team(models.Model):
     def __str__(self):
         return self.name
 
-    def _post_save(self, creating):
-        """Post save hooks"""
-        if creating:
-            Environment = apps.get_model("core", "Environment")
-            Environment.create_default(self)
-
-    def save(self, *args, **kwargs):
-        creating = self._state.adding
-
-        with transaction.atomic():
-            team = super().save(*args, **kwargs)
-            self._post_save(creating)
-
-        return team
+    def post_create(self):
+        """Post create hooks"""
+        Environment = apps.get_model("core", "Environment")
+        Environment.create_default(self)

--- a/functionary/core/utils/messaging.py
+++ b/functionary/core/utils/messaging.py
@@ -1,0 +1,139 @@
+import json
+import logging
+import ssl
+from typing import Tuple
+
+import pika
+from django.conf import settings
+from pika.exceptions import UnroutableError
+from pika.exchange_type import ExchangeType
+
+logger = logging.getLogger(__name__)
+
+PUBLIC_EXCHANGE = "runners.public"
+PUBLIC_QUEUE = "public"
+TASK_RESULTS_QUEUE = "tasking.results"
+
+
+def build_connection(ca=None, cert=None, key=None, open_callback=None):
+    """Creates a connection to RabbitMQ.
+
+    This will use the RABBITMQ_[USER,PASSWORD,HOST,PORT] environment
+    variables to open a connection to RabbitMQ. Optionally pass in
+    certificate information and/or a callback function.
+
+    Args:
+      ca: The path to the CA file for the SSL context
+      cert: The path to the user certifcate
+      key: The path to the keyfile for the given certificate
+      open_callback: If populated, will return a select connection
+        with this as the open callback.
+
+    Returns:
+      A pika.SelectConnection if open_callback is populated, otherwise
+      a pika.BlockingConnection.
+    """
+    connection_params = {
+        "host": settings.RABBITMQ_HOST,
+        "port": settings.RABBITMQ_PORT,
+    }
+
+    if cert:
+        context = ssl.create_default_context(cafile=ca)
+        context.load_cert_chain(cert, key)
+        connection_params["ssl_options"] = pika.SSLOptions(context, "localhost")
+    elif settings.RABBITMQ_USER is not None:
+        connection_params["credentials"] = pika.PlainCredentials(
+            settings.RABBITMQ_USER, settings.RABBITMQ_PASSWORD
+        )
+
+    if open_callback:
+        return pika.SelectConnection(
+            pika.ConnectionParameters(**connection_params),
+            on_open_callback=open_callback,
+        )
+    else:
+        return pika.BlockingConnection(pika.ConnectionParameters(**connection_params))
+
+
+def get_route(task) -> Tuple[str, str]:
+    """Determine the correct exchange and routing key for provided task
+
+    Args:
+        task: Task instance to determine routing information for
+
+    Returns:
+        A tuple of strings: (exchange, routing_key)
+    """
+    # TODO: Implement actual routing determination logic. For now, this always returns
+    #       the public runner pool exchange and routing key
+    return (PUBLIC_EXCHANGE, PUBLIC_QUEUE)
+
+
+def send_message(exchange, routing_key, msg_type, message):
+    """Sends a JSON message to the specified queue.
+
+    Sends the given message to the queue. If msg_type is populated, it
+    sets the x-msg-type header to that value.
+
+    Args:
+        exchange: The message broker exchange to send the message to
+        routing_key: The routing key to use when delivering the message
+        msg_type: The value of x-msg-type to set in the header, or None
+        message: The message to send, must be valid JSON.
+
+    Raises:
+        pika.exceptions.UnroutableError: if unable to publish the message
+    """
+
+    headers = {"x-msg-type": msg_type} if msg_type else {}
+
+    # TODO Update this to use a persistent connection to the queue
+    publish_props = pika.BasicProperties(
+        content_type="application/json",
+        content_encoding="utf-8",
+        headers=headers,
+        delivery_mode=1,
+    )
+
+    connection = build_connection()
+    channel = connection.channel()
+    channel.confirm_delivery()
+
+    try:
+        channel.basic_publish(
+            exchange=exchange,
+            routing_key=routing_key,
+            body=json.dumps(message),
+            properties=publish_props,
+            mandatory=True,
+        )
+    except UnroutableError as ue:
+        # TODO revisit this and handle exceptions better. Currently used for retry logic
+        logger.error("Failed to send message to %s using %s", exchange, routing_key)
+        raise ue
+    finally:
+        connection.close()
+
+
+def initialize_messaging():
+    """Declares the exchanges and queues necessary for communicating with the runners"""
+    connection = build_connection()
+    channel = connection.channel()
+
+    logger.debug("Configuring rabbitmq exchange: %s", PUBLIC_EXCHANGE)
+    channel.exchange_declare(
+        PUBLIC_EXCHANGE,
+        exchange_type=ExchangeType.direct,
+        durable=True,
+        auto_delete=False,
+    )
+    logger.debug("Configuring rabbitmq queue: %s", PUBLIC_QUEUE)
+    channel.queue_declare(PUBLIC_QUEUE, durable=True, auto_delete=False)
+    channel.queue_bind(PUBLIC_QUEUE, PUBLIC_EXCHANGE)
+
+    logger.debug("Configuring rabbitmq queue: %s", TASK_RESULTS_QUEUE)
+    channel.queue_declare(TASK_RESULTS_QUEUE, durable=True, auto_delete=False)
+
+    channel.close()
+    connection.close()

--- a/functionary/core/utils/tasking.py
+++ b/functionary/core/utils/tasking.py
@@ -1,0 +1,44 @@
+import logging
+from uuid import UUID
+
+from celery.utils.log import get_task_logger
+from django.conf import settings
+
+from core.celery import app
+from core.models import Task
+from core.utils.messaging import get_route, send_message
+
+logger = get_task_logger(__name__)
+logger.setLevel(getattr(logging, settings.LOG_LEVEL))
+
+
+def _generate_task_message(task: Task) -> dict:
+    """Generates tasking message from the provided Task"""
+    return {
+        "id": str(task.id),
+        "package": task.function.package.full_image_name,
+        "function": task.function.name,
+        "function_parameters": task.parameters,
+    }
+
+
+@app.task(
+    default_retry_delay=30,
+    retry_kwargs={
+        "max_retries": 3,
+    },
+    autoretry_for=(Exception,),
+)
+def publish_task(task_id: UUID) -> None:
+    """Publish the tasking message to the message broker so that it can be received
+    and executed by a runner.
+
+    Args:
+        task_id: ID of the task to be executed
+    """
+    logger.debug(f"Publishing message for Task: {task_id}")
+
+    task = Task.objects.select_related("function", "function__package").get(id=task_id)
+
+    exchange, routing_key = get_route(task)
+    send_message(exchange, routing_key, "TASK_PACKAGE", _generate_task_message(task))

--- a/functionary/functionary/settings/__init__.py
+++ b/functionary/functionary/settings/__init__.py
@@ -3,4 +3,5 @@ from .celery_ import *  # noqa
 from .core_ import *  # noqa
 from .django_ import *  # noqa
 from .logging_ import *  # noqa
+from .rabbitmq_ import *  # noqa
 from .rest_framework_ import *  # noqa

--- a/functionary/functionary/settings/logging_.py
+++ b/functionary/functionary/settings/logging_.py
@@ -14,4 +14,12 @@ LOGGING = {
         "handlers": ["console"],
         "level": LOG_LEVEL,
     },
+    "loggers": {
+        "celery": {
+            "level": LOG_LEVEL,
+        },
+        "pika": {
+            "level": "WARNING",
+        },
+    },
 }

--- a/functionary/functionary/settings/rabbitmq_.py
+++ b/functionary/functionary/settings/rabbitmq_.py
@@ -1,0 +1,6 @@
+import os
+
+RABBITMQ_HOST = os.getenv("RABBITMQ_HOST", "localhost")
+RABBITMQ_PORT = os.getenv("RABBITMQ_PORT", 5672)
+RABBITMQ_USER = os.getenv("RABBITMQ_USER")
+RABBITMQ_PASSWORD = os.getenv("RABBITMQ_PASSWORD")

--- a/functionary/requirements.in
+++ b/functionary/requirements.in
@@ -2,6 +2,7 @@ celery
 django
 docker
 jsonschema
+pika
 pydantic
 pyyaml
 redis

--- a/functionary/requirements.txt
+++ b/functionary/requirements.txt
@@ -64,6 +64,8 @@ packaging==21.3
     # via
     #   docker
     #   redis
+pika==1.3.0
+    # via -r requirements.in
 prompt-toolkit==3.0.30
     # via click-repl
 pydantic==1.9.2

--- a/runner/README.md
+++ b/runner/README.md
@@ -3,3 +3,17 @@
 The runner is the service that actually executes tasks in Functionary. It is
 responsible for starting up the package container, executing a function, and
 reporting the results back to the core application.
+
+To launch the runner, you need to start two separate processes:
+
+```shell
+# required env variables
+export RABBITMQ_USER=someuser
+export RABBITMQ_PASSWORD=greatpassword
+
+# start the listener
+LOG_LEVEL=INFO python ./main.py
+
+# start the worker
+celery -A runner worker --loglevel=INFO
+```

--- a/runner/README.md
+++ b/runner/README.md
@@ -4,16 +4,22 @@ The runner is the service that actually executes tasks in Functionary. It is
 responsible for starting up the package container, executing a function, and
 reporting the results back to the core application.
 
-To launch the runner, you need to start two separate processes:
+To launch the runner, you need to start two separate processes. Both require
+environment variables be set for connecting to the message broker:
 
+- RABBITMQ_USER (required)
+- RABBITMQ_PASSWORD (required)
+- RABBITMQ_HOST (optional: defaults to localhost)
+- RABBITMQ_PORT (optional: defaults to 5672)
+
+Once you have configured the environment, you can run the two process:
+
+## Listener
 ```shell
-# required env variables
-export RABBITMQ_USER=someuser
-export RABBITMQ_PASSWORD=greatpassword
-
-# start the listener
 LOG_LEVEL=INFO python ./main.py
+```
 
-# start the worker
+## Worker
+```shell
 celery -A runner worker --loglevel=INFO
 ```

--- a/runner/main.py
+++ b/runner/main.py
@@ -1,4 +1,11 @@
+import logging
+import os
+
 from runner.listener import start_listening
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+
+logging.basicConfig(level=LOG_LEVEL)
 
 if __name__ == "__main__":
     start_listening()

--- a/runner/runner/celery.py
+++ b/runner/runner/celery.py
@@ -1,8 +1,13 @@
+import os
+
 from celery import Celery
+
+REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
+REDIS_PORT = os.getenv("REDIS_PORT", "6379")
 
 app = Celery(
     "runner",
-    broker="redis://redis",
+    broker=f"redis://{REDIS_HOST}:{REDIS_PORT}",
     include=["runner.handlers"],
 )
 

--- a/runner/runner/handlers.py
+++ b/runner/runner/handlers.py
@@ -83,4 +83,6 @@ def _parse_container_logs(logs):
     autoretry_for=(Exception,),
 )
 def publish_result(self, result):
+    # TODO: The routing key should come from the configuration information received
+    #       during runner registration.
     send_message("tasking.results", "TASK_RESULT", result)

--- a/runner/runner/handlers.py
+++ b/runner/runner/handlers.py
@@ -1,7 +1,6 @@
 import itertools
 import json
 import logging
-import os
 
 from celery import Task
 
@@ -16,8 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 class PackageClient(Task):
-    REGISTRY = os.environ.get("REGISTRY", "localhost:5000")
-
     def __init__(self):
         self._docker = docker.from_env()
 
@@ -33,15 +30,13 @@ class PackageClient(Task):
 )
 def pull_image(self, task) -> None:
     package = task.get("package")
-    fqi = f"{self.REGISTRY}/{package}"
-    self._docker.images.pull(fqi)
+    self._docker.images.pull(package)
 
-    logger.debug(f"Pulled {fqi}")
-    return task
+    logger.debug(f"Pulled {package}")
 
 
 @app.task(base=PackageClient, bind=True)
-def run_task(self, task):
+def run_task(self, _=None, task=None):
     exit_status, output, result = _run_task(self, task)
 
     return {
@@ -87,5 +82,5 @@ def _parse_container_logs(logs):
     },
     autoretry_for=(Exception,),
 )
-def publish_result(self, result, topic):
-    send_message(topic, "TASK_RESULT", result)
+def publish_result(self, result):
+    send_message("tasking.results", "TASK_RESULT", result)


### PR DESCRIPTION
Closes #56 

This PR adds message publishing to the RabbitMQ broker when a Task instance is created.  This is done via a `post_create` hook on the Task model.

There are also a lot of incidental changes both directly and indirectly related to that.  Comments will be provided on specific lines in the PR.

## Test Instructions
* The READMEs have been updated to include instructions on how to configure the RABBITMQ username and password, as well as how to start the worker and runner processes.  Try following those instructions to ensure that they are accurate.
* Once everything is running, create a new Task.
* You should see the runner listener pick up the message and had it over to the runner celery worker, which will execute the tasking and publish a message with the results.  This should be visible in the logs, but also if you check the "tasking.results" queue in RabbitMQ, there should be a message there.