### PR TITLE
Add additional parameter types.

### DIFF
--- a/functionary/builder/api/v1/serializers/package_definition.py
+++ b/functionary/builder/api/v1/serializers/package_definition.py
@@ -1,6 +1,18 @@
 """ Serializers for defining a package """
 from rest_framework import serializers
 
+LANGUAGES = [("python", "Python"), ("javascript", "JavaScript")]
+PARAMETER_TYPES = [
+    ("integer", "Integer"),
+    ("string", "String"),
+    ("text", "String (Long)"),
+    ("float", "Float"),
+    ("boolean", "Boolean"),
+    ("date", "Date"),
+    ("datetime", "Date Time"),
+    ("json", "JSON"),
+]
+
 
 class ParameterOptionSerializer(serializers.Serializer):
     name = serializers.CharField()
@@ -17,8 +29,7 @@ class ParameterSerializer(serializers.Serializer):
     display_name = serializers.CharField(required=False)
     description = serializers.CharField(required=False)
 
-    # TODO: This should likely be limited to known choices
-    type = serializers.CharField(required=True)
+    type = serializers.ChoiceField(choices=PARAMETER_TYPES, required=True)
 
     required = serializers.BooleanField(default=False)
     options = ParameterOptionSerializer(many=True, required=False)
@@ -43,7 +54,7 @@ class PackageDefinitionSerializer(serializers.Serializer):
     name = serializers.CharField()
     display_name = serializers.CharField(required=False)
     description = serializers.CharField(required=False)
-    language = serializers.CharField(required=False)
+    language = serializers.ChoiceField(choices=LANGUAGES, required=False)
     filename = serializers.CharField(required=False)
     environment = serializers.DictField(child=serializers.CharField(), required=False)
     functions = FunctionSerializer(many=True)

--- a/functionary/builder/utils.py
+++ b/functionary/builder/utils.py
@@ -1,8 +1,10 @@
+import datetime
 import io
 import logging
 import os
 import shutil
 import tarfile
+from typing import TypeVar
 from uuid import UUID
 
 import docker
@@ -11,7 +13,7 @@ from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.db import transaction
 from django.template.loader import get_template
-from pydantic import Field, create_model
+from pydantic import Field, Json, create_model
 
 from core.models import Environment, Function, Package, User
 
@@ -218,8 +220,16 @@ def _create_functions_from_definition(definitions, package: Package):
 def _generate_function_schema(name: str, parameters) -> str:
     """Creates a pydantic model from the parameter definitions and returns the schema
     as a JSON string"""
-    # TODO - Update this map to add lists and whatever other pieces we want to support
-    type_map = {"int": int, "str": str}
+    type_map = {
+        "integer": int,
+        "string": str,
+        "text": TypeVar("text", str, bytes),
+        "float": float,
+        "boolean": bool,
+        "date": datetime.date,
+        "datetime": datetime.datetime,
+        "json": TypeVar("json", Json, str),
+    }
     params_dict = {}
 
     for parameter in parameters:

--- a/functionary/core/models/task.py
+++ b/functionary/core/models/task.py
@@ -5,6 +5,7 @@ from typing import Optional
 import jsonschema
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 
 from core.models import ModelSaveHookMixin
@@ -44,7 +45,7 @@ class Task(ModelSaveHookMixin, models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     function = models.ForeignKey(to="Function", on_delete=models.CASCADE)
     environment = models.ForeignKey(to="Environment", on_delete=models.CASCADE)
-    parameters = models.JSONField()
+    parameters = models.JSONField(encoder=DjangoJSONEncoder)
     status = models.CharField(max_length=16, choices=STATUS_CHOICES, default=PENDING)
     creator = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.PROTECT)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/functionary/ui/forms/forms.py
+++ b/functionary/ui/forms/forms.py
@@ -36,10 +36,18 @@ _field_mapping = {
     "json": (JSONField, Textarea),
 }
 
-_transform_intitial_mapping = {"json": json.loads}
+_transform_initial_mapping = {"json": json.loads}
 
 
-def get_param_type(param_dict):
+def _get_param_type(param_dict):
+    """Finds the type of the parameter from the definition in the schema.
+
+    Pydantic maps to python types correctly, but we want to use the actual
+    schema type for input purposes. If there is a format in the param_dict,
+    the input field has a definition of what type it is. If there is an anyOf,
+    inspect it and try find out what type it should be. Otherwise, return the
+    value of 'type' in param_dict.
+    """
     keys = param_dict.keys()
 
     # pydantic hides the date type in the format field
@@ -59,6 +67,22 @@ def get_param_type(param_dict):
         return param_dict["type"]
 
 
+def _prepare_initial_value(param_type, initial):
+    """Convert the initial value to the appropriate type.
+
+    This function will massage the initial value as needed into the type
+    required for the parameter field. Currently, JSON types need to be
+    converted from a string into an object, otherwise display issues
+    occur in the form.
+    """
+    if initial:
+        if param_type in _transform_initial_mapping:
+            return _transform_initial_mapping[param_type](initial)
+        else:
+            return initial
+    return None
+
+
 class TaskParameterForm(Form):
     template_name = "forms/task_parameters.html"
 
@@ -66,28 +90,28 @@ class TaskParameterForm(Form):
         super().__init__(data)
 
         for param, value in function.schema["properties"].items():
-            req = not value["default"]
             initial = value.get("default", None)
-            param_type = get_param_type(value)
-            kwargs = {
-                "label": value["title"],
-                "label_suffix": param_type,
-                "initial": initial,
-                "required": req,
-                "help_text": value.get("description", None),
-            }
-
+            req = initial is None
+            param_type = _get_param_type(value)
             field_class, widget = _field_mapping.get(param_type, (None, None))
 
             if not field_class:
                 raise ValueError(f"Unknown field type for {param}: {param_type}")
 
+            kwargs = {
+                "label": value["title"],
+                "label_suffix": param_type,
+                "initial": _prepare_initial_value(param_type, initial),
+                "required": req,
+                "help_text": value.get("description", None),
+            }
+
             if widget:
                 kwargs["widget"] = widget
-            if param_type in _transform_intitial_mapping:
-                kwargs["initial"] = _transform_intitial_mapping[param_type](initial)
 
             field = field_class(**kwargs)
+
+            # Style all inputfields except the checkbox with the "input" class
             if param_type != "boolean":
                 field.widget.attrs.update({"class": "input"})
             self.fields[param] = field

--- a/functionary/ui/forms/forms.py
+++ b/functionary/ui/forms/forms.py
@@ -1,27 +1,52 @@
+import json
+
 from django.forms import (
     BooleanField,
     CharField,
     DateField,
     DateTimeField,
-    DecimalField,
     FloatField,
     Form,
     IntegerField,
     JSONField,
-    TimeField,
+    Textarea,
 )
 
 _field_mapping = {
-    "integer": IntegerField,
-    "string": CharField,
-    "float": FloatField,
-    "double": DecimalField,
-    "boolean": BooleanField,
-    "date": DateField,  # TODO set input_formats= on constructor if needed
-    "datetime": DateTimeField,  # TODO set input_formats= on constructor if needed
-    "time": TimeField,  # TODO set input_formats= on constructor if needed
-    "object": JSONField,
+    "integer": (IntegerField, None),
+    "string": (CharField, None),
+    "text": (CharField, Textarea),
+    "number": (FloatField, None),
+    "boolean": (BooleanField, None),
+    "date": (DateField, None),
+    "date-time": (
+        DateTimeField,
+        None,
+    ),
+    "json": (JSONField, Textarea),
 }
+
+_transform_intitial_mapping = {"json": json.loads}
+
+
+def get_param_type(param_dict):
+    keys = param_dict.keys()
+
+    # pydantic hides the date type in the format field
+    if "format" in keys:
+        return param_dict["format"]
+    # json and text get mapped to TypeVars to preserve the distinction vs string
+    elif "anyOf" in keys:
+        return (
+            "json"
+            if any(
+                param_types.get("format", None) == "json-string"
+                for param_types in param_dict["anyOf"]
+            )
+            else "text"
+        )
+    else:
+        return param_dict["type"]
 
 
 class TaskParameterForm(Form):
@@ -31,20 +56,28 @@ class TaskParameterForm(Form):
         super().__init__(data)
 
         for param, value in function.schema["properties"].items():
-            req: bool = not value["default"]
+            req = not value["default"]
             initial = value.get("default", None)
+            param_type = get_param_type(value)
             kwargs = {
                 "label": value["title"],
-                "label_suffix": value["type"],
+                "label_suffix": param_type,
                 "initial": initial,
                 "required": req,
                 "help_text": value.get("description", None),
             }
-            field_class = _field_mapping.get(value["type"], None)
+
+            field_class, widget = _field_mapping.get(param_type, (None, None))
 
             if not field_class:
-                raise ValueError(f"Unknown field type for {param}: {value['type']}")
+                raise ValueError(f"Unknown field type for {param}: {param_type}")
+
+            if widget:
+                kwargs["widget"] = widget
+            if param_type in _transform_intitial_mapping:
+                kwargs["initial"] = _transform_intitial_mapping[param_type](initial)
 
             field = field_class(**kwargs)
-            field.widget.attrs.update({"class": "input"})
+            if param_type != "boolean":
+                field.widget.attrs.update({"class": "input"})
             self.fields[param] = field

--- a/functionary/ui/forms/forms.py
+++ b/functionary/ui/forms/forms.py
@@ -11,6 +11,16 @@ from django.forms import (
     JSONField,
     Textarea,
 )
+from django.forms.widgets import DateInput, DateTimeInput
+
+
+class HTMLDateInput(DateInput):
+    input_type = "date"
+
+
+class HTMLDateTimeInput(DateTimeInput):
+    input_type = "datetime-local"
+
 
 _field_mapping = {
     "integer": (IntegerField, None),
@@ -18,10 +28,10 @@ _field_mapping = {
     "text": (CharField, Textarea),
     "number": (FloatField, None),
     "boolean": (BooleanField, None),
-    "date": (DateField, None),
+    "date": (DateField, HTMLDateInput),
     "date-time": (
         DateTimeField,
-        None,
+        HTMLDateTimeInput,
     ),
     "json": (JSONField, Textarea),
 }

--- a/functionary/ui/static/css/functionary.css
+++ b/functionary/ui/static/css/functionary.css
@@ -21,3 +21,13 @@
 .environment-select * {
     color: black;
 }
+.errorlist > li {
+    color: red;
+}
+.errors {
+    color: red;
+}
+
+textarea.input {
+    height: 100px;
+}

--- a/functionary/ui/static/css/functionary.css
+++ b/functionary/ui/static/css/functionary.css
@@ -27,7 +27,6 @@
 .errors {
     color: red;
 }
-
 textarea.input {
     height: 100px;
 }

--- a/functionary/ui/templates/forms/task_parameters.html
+++ b/functionary/ui/templates/forms/task_parameters.html
@@ -1,13 +1,13 @@
 {% for field in form %}
 <div class="field">
-    {{ field.errors }}
     <label class="label" for="{{ field.id_for_label }}">
-        <b>{{ field.label }}</b>: 
+        <b {% if field.errors %}class="errors"{% endif %}>{{ field.label }}</b>: 
         <span class="is-small has-text-grey-light">{{ field.field.label_suffix }}</span>
         &nbsp;&nbsp;&nbsp;{{ field.help_text }}
     </label>
     <div class="control">
         {{ field }}
     </div>
+    {{ field.errors }}
 </div>
 {% endfor %}

--- a/functionary/ui/templates/unicorn/task_detail.html
+++ b/functionary/ui/templates/unicorn/task_detail.html
@@ -27,21 +27,17 @@
             <label class="label" for="params">
                 <i class="fa fa-list"></i>&nbsp;Parameters:
             </label>
-            <ul id="params">
-                <li class="block ml-4">
-                    <p class="is-font-monospace">{{ task.parameters }}</p>
-                </li>
-            </ul>
+            <div id="params">
+                <pre class="block ml-4">{{ task.parameters | pprint }}</pre>
+            </div>
         </div>
         <div class="field">
             <label class="label" for="result">
                 <i class="fa fa-clipboard-check"></i>&nbsp;Result:
             </label>
-            <ul id="result">
-                {% if task.result is not None %}
-                    <li class="block ml-4">{{ task.result }}</li>
-                {% endif %}
-            </ul>
+            <div id="result">
+                {% if task.result is not None %}<pre class="block ml-4">{{ task.result }}</pre>{% endif %}
+            </div>
         </div>
     </div>
 </div>

--- a/functionary/ui/views/functions.py
+++ b/functionary/ui/views/functions.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, HttpResponseForbidden, HttpResponseRedirect
+from django.shortcuts import render
 from django.urls import reverse
 from django.views.decorators.http import require_POST
 
@@ -55,5 +56,7 @@ def execute(request) -> HttpResponse:
 
             # redirect to a new URL:
             return HttpResponseRedirect(reverse("ui:task-detail", args=(task.id,)))
+        args = {"form": form, "function": func}
+        return render(request, "core/function_detail.html", args)
 
     return HttpResponseForbidden()


### PR DESCRIPTION
This PR adds support for the following datatypes:
- string (assumed short input)
- text (longer form input)
- integer
- float
- boolean
- date
- datetime
- json

The json field is parsed and validated that it is json. This allows for object or lists of JSON supported types to be passed to the function.

All the fields are validated to be of the correct datatype and the page will display error messages below the failing fields.

This was tested by making a function with all the possible parameter types and printing the value received by the function in the docker runner. 