### PR TITLE
Issue 65: change save host line location

### DIFF
--- a/cli/functionary/login.py
+++ b/cli/functionary/login.py
@@ -16,7 +16,7 @@ def login_cmd(ctx, user, password, host):
     Set the output of this command to the FUNCTIONARY_TOKEN environment variable
     for other functionary commands to use to communicate with the server.
     """
-    save_config_value("host", host)
     token = login(host, user, password)
+    save_config_value("host", host)
     save_config_value("token", token)
     click.echo("Login successful!")


### PR DESCRIPTION
Closes #65 

Really simple change that just stores the host after the login function successfully runs. I want to say that the host not being in the same section of code as the token was a holdover from the time I was trying to make the login use the same centralized get/post commands as everything else