### PR TITLE
Issue 73: add summary field for package and function

### DIFF
--- a/cli/functionary/package.py
+++ b/cli/functionary/package.py
@@ -41,6 +41,7 @@ def package_cmd(ctx):
     "-l",
     type=click.Choice(create_languages(), case_sensitive=False),
     required=True,
+    prompt="Select the language",
 )
 @click.option("--output-directory", "-o", type=click.Path(exists=True), default=".")
 @click.argument("name", type=str)

--- a/cli/functionary/package.py
+++ b/cli/functionary/package.py
@@ -140,8 +140,12 @@ def list(ctx):
         function_dict = {}
         function_dict["Function"] = function["name"]
         function_dict["Display Name"] = function["display_name"]
-        function_dict["Summary"] = function["summary"]
-        function_dict["Description"] = function["description"]
+
+        # Use the summary if available to keep the table tidy, otherwise
+        # use the description
+        if not (description := function.get("summary", None)):
+            description = function["description"]
+        function_dict["Description"] = description if description else ""
 
         if package_id in functions_lookup:
             functions_lookup[package_id].append(function_dict)
@@ -151,11 +155,16 @@ def list(ctx):
     for package in packages:
         name = package["name"]
         id = package["id"]
-        summary = package["summary"]
-        description = package["description"]
+        # Use the description since there's more room if it's available,
+        # otherwise use the summary
+        if not (description := package.get("description", None)):
+            description = package["summary"]
         associated_functions = functions_lookup[id]
+
         title = Text(f"{name}", style="bold blue")
-        title.append(f"\n{summary}", style="blue dim")
-        title.append(f"\n{description}", style="blue dim")
+
+        # Don't show if there's no package summary or description
+        if description:
+            title.append(f"\n{description}", style="blue dim")
         format_results(associated_functions, title=title)
         click.echo("\n")

--- a/cli/functionary/package.py
+++ b/cli/functionary/package.py
@@ -140,6 +140,7 @@ def list(ctx):
         function_dict = {}
         function_dict["Function"] = function["name"]
         function_dict["Display Name"] = function["display_name"]
+        function_dict["Summary"] = function["summary"]
         function_dict["Description"] = function["description"]
 
         if package_id in functions_lookup:
@@ -150,9 +151,11 @@ def list(ctx):
     for package in packages:
         name = package["name"]
         id = package["id"]
+        summary = package["summary"]
         description = package["description"]
         associated_functions = functions_lookup[id]
         title = Text(f"{name}", style="bold blue")
+        title.append(f"\n{summary}", style="blue dim")
         title.append(f"\n{description}", style="blue dim")
         format_results(associated_functions, title=title)
         click.echo("\n")

--- a/cli/functionary/templates/package.yaml
+++ b/cli/functionary/templates/package.yaml
@@ -7,6 +7,9 @@ package:
   #   # (optional) defaults to name; determines how the package is displayed in the UI
   #   display_name: string
 
+  #   # (optional) short summary of the packages purpose
+  #   summary: string
+
   #   # (optional) detailed description
   #   description: string
 
@@ -16,6 +19,7 @@ package:
   functions:
 #    # similar to package level fields, but for the function
 #    - name: string
+#      summary: string
 #      display_name: string
 #      description: string
 
@@ -25,6 +29,8 @@ package:
 #        - name: string
 #          # (optional) defaults to name; determines how the parameter is displayed in the UI
 #          display_name: string
+#          # (optional) short summary of the functions purpose
+#          summary: string
 #          # (optional) detailed description
 #          description: string
 #          # (required) data type of the parameter

--- a/examples/calculator/package.yaml
+++ b/examples/calculator/package.yaml
@@ -5,8 +5,13 @@ package:
   # (required) human-friendly unique identifier (team + package name must be unique)
   name: calculator
 
+  # (optional) Summary of the packages purpose
+  summary: Simple calculator example package
+
   # (optional) Detailed description
-  description: Simple calculator example package
+  description:
+    The calculator package contains many functions useful for calculating
+    values. One of these functions is production ready.
 
   # (required) Language that the functions are written in
   language: python
@@ -15,7 +20,8 @@ package:
   functions:
     # Similar to package level fields, but for the function
     - name: add
-      description: add two ints
+      summary: Add two integers
+      description: This function consumes two integers and outputs the sum.
 
       # (required) Parameters that the function takes
       parameters:

--- a/functionary/builder/api/v1/serializers/package_definition.py
+++ b/functionary/builder/api/v1/serializers/package_definition.py
@@ -44,7 +44,7 @@ class FunctionSerializer(serializers.Serializer):
 
     name = serializers.CharField()
     display_name = serializers.CharField(required=False)
-    summary = serializers.CharField(max_length=50, required=False)
+    summary = serializers.CharField(max_length=128, required=False)
     description = serializers.CharField(required=False)
     parameters = ParameterSerializer(many=True)
 
@@ -54,7 +54,7 @@ class PackageDefinitionSerializer(serializers.Serializer):
 
     name = serializers.CharField()
     display_name = serializers.CharField(required=False)
-    summary = serializers.CharField(max_length=50, required=False)
+    summary = serializers.CharField(max_length=128, required=False)
     description = serializers.CharField(required=False)
     language = serializers.ChoiceField(choices=LANGUAGES, required=False)
     filename = serializers.CharField(required=False)

--- a/functionary/builder/api/v1/serializers/package_definition.py
+++ b/functionary/builder/api/v1/serializers/package_definition.py
@@ -44,6 +44,7 @@ class FunctionSerializer(serializers.Serializer):
 
     name = serializers.CharField()
     display_name = serializers.CharField(required=False)
+    summary = serializers.CharField(max_length=50, required=False)
     description = serializers.CharField(required=False)
     parameters = ParameterSerializer(many=True)
 
@@ -53,6 +54,7 @@ class PackageDefinitionSerializer(serializers.Serializer):
 
     name = serializers.CharField()
     display_name = serializers.CharField(required=False)
+    summary = serializers.CharField(max_length=50, required=False)
     description = serializers.CharField(required=False)
     language = serializers.ChoiceField(choices=LANGUAGES, required=False)
     filename = serializers.CharField(required=False)

--- a/functionary/builder/utils.py
+++ b/functionary/builder/utils.py
@@ -190,6 +190,7 @@ def _create_package_from_definition(
         )
 
     package_obj.display_name = package_definition.get("display_name")
+    package_obj.summary = package_definition.get("summary")
     package_obj.description = package_definition.get("description")
     package_obj.language = package_definition.get("language")
     package_obj.image_name = image_name
@@ -210,6 +211,7 @@ def _create_functions_from_definition(definitions, package: Package):
             function_obj = Function(package=package, name=name)
 
         function_obj.display_name = function_def.get("display_name")
+        function_obj.summary = function_def.get("summary")
         function_obj.description = function_def.get("description")
         function_obj.schema = _generate_function_schema(
             name, function_def.get("parameters")

--- a/functionary/core/models/function.py
+++ b/functionary/core/models/function.py
@@ -26,7 +26,7 @@ class Function(models.Model):
     name = models.CharField(max_length=64, blank=False)
 
     display_name = models.CharField(max_length=64, null=True)
-    summary = models.CharField(max_length=50, null=True)
+    summary = models.CharField(max_length=128, null=True)
     description = models.TextField(null=True)
     schema = models.JSONField()
 

--- a/functionary/core/models/function.py
+++ b/functionary/core/models/function.py
@@ -25,6 +25,7 @@ class Function(models.Model):
     name = models.CharField(max_length=64, blank=False)
 
     display_name = models.CharField(max_length=64, null=True)
+    summary = models.CharField(max_length=50, null=True)
     description = models.TextField(null=True)
     schema = models.JSONField()
 

--- a/functionary/core/models/function.py
+++ b/functionary/core/models/function.py
@@ -12,6 +12,7 @@ class Function(models.Model):
         package: the package that the function is a part of
         name: internal name that published package definition keys off of
         display_name: optional display name
+        summary: short description of the function
         description: more details about the function
         schema: the function's OpenAPI definition
     """

--- a/functionary/core/models/package.py
+++ b/functionary/core/models/package.py
@@ -26,7 +26,7 @@ class Package(models.Model):
     name = models.CharField(max_length=64, blank=False)
 
     display_name = models.CharField(max_length=64, null=True)
-    summary = models.CharField(max_length=50, null=True)
+    summary = models.CharField(max_length=128, null=True)
     description = models.TextField(null=True)
 
     # TODO: Restrict to list of choices?

--- a/functionary/core/models/package.py
+++ b/functionary/core/models/package.py
@@ -15,7 +15,8 @@ class Package(models.Model):
         environment: the environment that this package belongs to
         name: internal name that published package definition keys off of
         display_name: optional display name
-        description: more details about the function
+        summary: summary of the package
+        description: more details about the package
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

--- a/functionary/core/models/package.py
+++ b/functionary/core/models/package.py
@@ -25,6 +25,7 @@ class Package(models.Model):
     name = models.CharField(max_length=64, blank=False)
 
     display_name = models.CharField(max_length=64, null=True)
+    summary = models.CharField(max_length=50, null=True)
     description = models.TextField(null=True)
 
     # TODO: Restrict to list of choices?

--- a/functionary/ui/templates/core/environment_detail.html
+++ b/functionary/ui/templates/core/environment_detail.html
@@ -1,38 +1,43 @@
 {% extends "base.html" %}
-
 {% block content %}
-
-<div class="column is-full">
-    <nav class="breadcrumb has-arrow-separator" aria-label="breadcrumbs">
-        <ul>
-            <li><a href="{% url 'ui:environment-list' %}">Environment List</a></li>
-            <li class="is-active"><a href="#">{{ environment.name }}</a></li>
-        </ul>
-    </nav>
-</div>
-<div class="column">
-    <div class="block">
-        <h1 class="title is-1">
-            <span class="icon"><i class="fa fa-building"></i></span>&nbsp;&nbsp;{{ environment.name }}
-        </h1>
+    <div class="column is-full">
+        <nav class="breadcrumb has-arrow-separator" aria-label="breadcrumbs">
+            <ul>
+                <li>
+                    <a href="{% url 'ui:environment-list' %}">Environment List</a>
+                </li>
+                <li class="is-active">
+                    <a href="#">{{ environment.name }}</a>
+                </li>
+            </ul>
+        </nav>
     </div>
-    <div class="column has-addons" >
-        <div class="columns">
-            <div class="column is-3">
-                <i class="fa fa-users"></i>&nbsp;{{ object.team.name }}
+    <div class="column">
+        <div class="block">
+            <h1 class="title is-1">
+                <span class="icon"><i class="fa fa-building"></i></span>&nbsp;&nbsp;{{ environment.name }}
+            </h1>
+        </div>
+        <div class="column has-addons">
+            <div class="columns">
+                <div class="column is-3">
+                    <i class="fa fa-users"></i>&nbsp;{{ object.team.name }}
+                </div>
+            </div>
+            <div class="field">
+                <label class="label" for="funcs">
+                    <i class="fa fa-cubes"></i>&nbsp;Packages:
+                </label>
+                <ul id="funcs">
+                    {% for package in packages %}
+                        <li class="block ml-4">
+                            <a href="{% url 'ui:package-detail' package.id %}">{{ package.name }}</a>
+                            <br/>
+                            {{ package.summary }}
+                        </li>
+                    {% endfor %}
+                </ul>
             </div>
         </div>
-        <div class="field">
-            <label class="label" for="funcs"><i class="fa fa-cubes"></i>&nbsp;Packages:</label>
-            <ul id="funcs">
-                {% for package in packages %}
-                <li class="block ml-4">
-                    <a href="{% url 'ui:package-detail' package.id %}">{{ package.name }}</a><br/>{{ package.description }}
-                </li>
-                {% endfor %}
-            </ul>
-        </div>
     </div>
-</div>
-
 {% endblock content %}

--- a/functionary/ui/templates/core/function_detail.html
+++ b/functionary/ui/templates/core/function_detail.html
@@ -1,55 +1,65 @@
 {% extends "base.html" %}
-
 {% load static %}
 {% load extras %}
-
 {% block content %}
-<div class="column is-full">
-    <nav class="breadcrumb has-arrow-separator" aria-label="breadcrumbs">
-        <ul>
-            <li><a href="{% url 'ui:function-list' %}">Function List</a></li>
-            <li><span class="icon mr-0 ml-2"><i class="fa fa-cubes"></i></span><a class="pl-0" href="{% url 'ui:package-detail' function.package.id %}">{{ function.package.name }}</a></li>
-            <li class="is-active"><a href="#">{{ function.name }}</a></li>
-        </ul>
-    </nav>
-</div>
-<div class="column">
-    <div class="block">
-        <h1 class="title is-1">
-            <span class="icon"><i class="fa fa-cube"></i></span>&nbsp;&nbsp;{{ function.name }}
-        </h1>
+    <div class="column is-full">
+        <nav class="breadcrumb has-arrow-separator" aria-label="breadcrumbs">
+            <ul>
+                <li>
+                    <a href="{% url 'ui:function-list' %}">Function List</a>
+                </li>
+                <li>
+                    <span class="icon mr-0 ml-2"><i class="fa fa-cubes"></i></span><a class="pl-0" href="{% url 'ui:package-detail' function.package.id %}">{{ function.package.name }}</a>
+                </li>
+                <li class="is-active">
+                    <a href="#">{{ function.name }}</a>
+                </li>
+            </ul>
+        </nav>
     </div>
-    {% if form %}
-    <form id="djangoForm" method="post" action="{% url 'ui:function-execute' %}">
-        {% csrf_token %}
-        <input type="hidden" name="function_id" value="{{ function.id }}"/>
-        <div class="column has-addons">
-            {{ form.non_field_errors }}
-            {{ form }}
-            <input class="button is-link" type="submit" value="Execute"/>
+    <div class="column">
+        <div class="block">
+            <h1 class="title is-1">
+                <span class="icon"><i class="fa fa-cube"></i></span>&nbsp;&nbsp;{{ function.name }}
+            </h1>
         </div>
-    </form>
-    {% endif %}
-    <div class="p-3 accordions">
-        <div class="accordion is-info {% if not form %} is-active {% endif %}">
-            <div class="accordion-header toggle">
-                <h3 class="is-4">Schema</h3>
-                <button class="button toggle"></button>
-            </div>
-            <div class="accordion-body">
-                <div class="accordion-content">
-                    <pre>{{ function.schema | pretty_json }}</pre>
+        <div class="field">
+            <label class="label" for="desc">Description:</label>
+            <span>{{ function.description }}</span>
+        </div>
+        {% if form %}
+            <form id="djangoForm"
+                  method="post"
+                  action="{% url 'ui:function-execute' %}">
+                {% csrf_token %}
+                <input type="hidden" name="function_id" value="{{ function.id }}"/>
+                <div class="column has-addons">
+                    {{ form.non_field_errors }}
+                    {{ form }}
+                    <input class="button is-link" type="submit" value="Execute"/>
+                </div>
+            </form>
+        {% endif %}
+        <div class="p-3 accordions">
+            <div class="accordion is-info {% if not form %} is-active{% endif %}">
+                <div class="accordion-header toggle">
+                    <h3 class="is-4">Schema</h3>
+                    <button class="button toggle"></button>
+                </div>
+                <div class="accordion-body">
+                    <div class="accordion-content">
+                        <pre>{{ function.schema | pretty_json }}</pre>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-
-<link rel="stylesheet" href="{% static 'css/bulma-accordion-2.0.1.min.css' %}"/>
-
-<script src="{% static 'js/bulma-accordion-2.0.1.min.js' %}" defer></script>
-
-<script>
-    window.addEventListener('load', (event) => { bulmaAccordion.attach(); });
-</script>
+    <link rel="stylesheet"
+          href="{% static 'css/bulma-accordion-2.0.1.min.css' %}"/>
+    <script src="{% static 'js/bulma-accordion-2.0.1.min.js' %}" defer></script>
+    <script>
+        window.addEventListener('load', (event) => {
+            bulmaAccordion.attach();
+        });
+    </script>
 {% endblock content %}

--- a/functionary/ui/templates/core/function_detail.html
+++ b/functionary/ui/templates/core/function_detail.html
@@ -12,7 +12,13 @@
                     <span class="icon mr-0 ml-2"><i class="fa fa-cubes"></i></span><a class="pl-0" href="{% url 'ui:package-detail' function.package.id %}">{{ function.package.name }}</a>
                 </li>
                 <li class="is-active">
-                    <a href="#">{{ function.name }}</a>
+                    <a href="#">
+                        {% if function.display_name %}
+                            {{ function.display_name }}
+                        {% else %}
+                            {{ function.name }}
+                        {% endif %}
+                    </a>
                 </li>
             </ul>
         </nav>
@@ -20,13 +26,26 @@
     <div class="column">
         <div class="block">
             <h1 class="title is-1">
-                <span class="icon"><i class="fa fa-cube"></i></span>&nbsp;&nbsp;{{ function.name }}
+                <span class="icon"><i class="fa fa-cube"></i></span>&nbsp;&nbsp;
+                {% if function.display_name %}
+                    {{ function.display_name }}
+                {% else %}
+                    {{ function.name }}
+                {% endif %}
             </h1>
         </div>
-        <div class="field">
-            <label class="label" for="desc">Description:</label>
-            <span>{{ function.description }}</span>
-        </div>
+        {% if function.summary %}
+            <div class="field ml-4">
+                <label class="label" for="desc">Summary:</label>
+                <span class="ml-4">{{ function.summary }}</span>
+            </div>
+        {% endif %}
+        {% if function.description %}
+            <div class="field ml-4">
+                <label class="label" for="desc">Description:</label>
+                <span class="ml-4">{{ function.description }}</span>
+            </div>
+        {% endif %}
         {% if form %}
             <form id="djangoForm"
                   method="post"

--- a/functionary/ui/templates/core/function_list.html
+++ b/functionary/ui/templates/core/function_list.html
@@ -1,42 +1,38 @@
 {% extends "base.html" %}
-
 {% block content %}
-
-<div>
-    {% for function in object_list %}
-    <div class="block">
-        <div class="card">
-            <div class="card-content">
-                <div class="media">
-                    <div class="media-left">
-                        <span class="icon is-large">
-                            <i class="fa fa-2x fa-cube"></i>
-                        </span>
-                    </div>
-                    <div class="media-content">
-                      <a href="{% url 'ui:function-detail' function.id %}">
-                        <p class="title is-4">
-                            {% if function.display_name %}
-                            {{ function.display_name }} ({{ function.name }})
-                            {% else %}
-                            {{ function.name }}
-                            {% endif %}
-                        </p>
-                        </a>
-                        <p class="subtitle is-6">
-                            <a class="has-text-info" href="{% url 'ui:package-detail' function.package.id %}">
-                                <span class="icon"><i class="fa fa-cubes"></i></span>&nbsp;{{ function.package.name|lower }}
-                            </a>
-                        </p>
-                        <p class="subtitle is-6">
-                            {{ function.description }}
-                        </p>
+    <div>
+        {% for function in object_list %}
+            <div class="block">
+                <div class="card">
+                    <div class="card-content">
+                        <div class="media">
+                            <div class="media-left">
+                                <span class="icon is-large">
+                                    <i class="fa fa-2x fa-cube"></i>
+                                </span>
+                            </div>
+                            <div class="media-content">
+                                <a href="{% url 'ui:function-detail' function.id %}">
+                                    <p class="title is-4">
+                                        {% if function.display_name %}
+                                            {{ function.display_name }} ({{ function.name }})
+                                        {% else %}
+                                            {{ function.name }}
+                                        {% endif %}
+                                    </p>
+                                </a>
+                                <p class="subtitle is-6">
+                                    <a class="has-text-info"
+                                       href="{% url 'ui:package-detail' function.package.id %}">
+                                        <span class="icon"><i class="fa fa-cubes"></i></span>&nbsp;{{ function.package.name|lower }}
+                                    </a>
+                                </p>
+                                {% if function.summary %}<p class="subtitle is-6">{{ function.summary }}</p>{% endif %}
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
+        {% endfor %}
     </div>
-    {% endfor %}
-</div>
-
 {% endblock content %}

--- a/functionary/ui/templates/core/package_detail.html
+++ b/functionary/ui/templates/core/package_detail.html
@@ -1,38 +1,47 @@
 {% extends "base.html" %}
-
 {% block content %}
-
-<div class="column is-full">
-    <nav class="breadcrumb has-arrow-separator" aria-label="breadcrumbs">
-        <ul>
-            <li><a href="{% url 'ui:package-list' %}">Package List</a></li>
-            <li class="is-active"><a href="#">{{ package.name }}</a></li>
-        </ul>
-    </nav>
-</div>
-<div class="column">
-    <div class="block">
-        <h1 class="title is-1">
-            <span class="icon"><i class="fa fa-cubes"></i></span>&nbsp;&nbsp;{{ package.name }}
-        </h1>
+    <div class="column is-full">
+        <nav class="breadcrumb has-arrow-separator" aria-label="breadcrumbs">
+            <ul>
+                <li>
+                    <a href="{% url 'ui:package-list' %}">Package List</a>
+                </li>
+                <li class="is-active">
+                    <a href="#">{{ package.name }}</a>
+                </li>
+            </ul>
+        </nav>
     </div>
-    <div class="column has-addons" >
-        <div class="columns">
-            <div class="column is-3">
-                <i class="fa fa-users"></i>&nbsp;{{ object.environment.team.name }}
+    <div class="column">
+        <div class="block">
+            <h1 class="title is-1">
+                <span class="icon"><i class="fa fa-cubes"></i></span>&nbsp;&nbsp;{{ package.name }}
+            </h1>
+        </div>
+        <div class="column has-addons">
+            <div class="columns">
+                <div class="column is-3">
+                    <i class="fa fa-users"></i>&nbsp;{{ object.environment.team.name }}
+                </div>
+            </div>
+            <div class="field">
+                <label class="label" for="desc">Description:</label>
+                <span>{{ package.description }}</span>
+            </div>
+            <div class="field">
+                <label class="label" for="funcs">
+                    <i class="fa fa-cube"></i>&nbsp;Functions:
+                </label>
+                <ul id="funcs">
+                    {% for function in functions %}
+                        <li class="block ml-4">
+                            <a href="{% url 'ui:function-detail' function.id %}">{{ function.name }}</a>
+                            <br/>
+                            {{ function.summary }}
+                        </li>
+                    {% endfor %}
+                </ul>
             </div>
         </div>
-        <div class="field">
-            <label class="label" for="funcs"><i class="fa fa-cube"></i>&nbsp;Functions:</label>
-            <ul id="funcs">
-                {% for function in functions %}
-                <li class="block ml-4">
-                    <a href="{% url 'ui:function-detail' function.id %}">{{ function.name }}</a><br/>{{ function.description }}
-                </li>
-                {% endfor %}
-            </ul>
-        </div>
     </div>
-</div>
-
 {% endblock content %}

--- a/functionary/ui/templates/core/package_detail.html
+++ b/functionary/ui/templates/core/package_detail.html
@@ -7,7 +7,13 @@
                     <a href="{% url 'ui:package-list' %}">Package List</a>
                 </li>
                 <li class="is-active">
-                    <a href="#">{{ package.name }}</a>
+                    <a href="#">
+                        {% if package.display_name %}
+                            {{ package.display_name }}
+                        {% else %}
+                            {{ package.name }}
+                        {% endif %}
+                    </a>
                 </li>
             </ul>
         </nav>
@@ -15,19 +21,27 @@
     <div class="column">
         <div class="block">
             <h1 class="title is-1">
-                <span class="icon"><i class="fa fa-cubes"></i></span>&nbsp;&nbsp;{{ package.name }}
+                <span class="icon"><i class="fa fa-cubes"></i></span>&nbsp;&nbsp;
+                {% if package.display_name %}
+                    {{ package.display_name }}
+                {% else %}
+                    {{ package.name }}
+                {% endif %}
             </h1>
         </div>
         <div class="column has-addons">
-            <div class="columns">
-                <div class="column is-3">
-                    <i class="fa fa-users"></i>&nbsp;{{ object.environment.team.name }}
+            {% if package.summary %}
+                <div class="field">
+                    <label class="label" for="desc">Summary:</label>
+                    <span class="ml-4">{{ package.summary }}</span>
                 </div>
-            </div>
-            <div class="field">
-                <label class="label" for="desc">Description:</label>
-                <span>{{ package.description }}</span>
-            </div>
+            {% endif %}
+            {% if package.description %}
+                <div class="field">
+                    <label class="label" for="desc">Description:</label>
+                    <span class="ml-4">{{ package.description }}</span>
+                </div>
+            {% endif %}
             <div class="field">
                 <label class="label" for="funcs">
                     <i class="fa fa-cube"></i>&nbsp;Functions:
@@ -35,9 +49,15 @@
                 <ul id="funcs">
                     {% for function in functions %}
                         <li class="block ml-4">
-                            <a href="{% url 'ui:function-detail' function.id %}">{{ function.name }}</a>
+                            <a href="{% url 'ui:function-detail' function.id %}">
+                                {% if function.display_name %}
+                                    {{ function.display_name }}
+                                {% else %}
+                                    {{ function.name }}
+                                {% endif %}
+                            </a>
                             <br/>
-                            {{ function.summary }}
+                            <span class="ml-4">{{ function.summary }}</span>
                         </li>
                     {% endfor %}
                 </ul>

--- a/functionary/ui/templates/core/package_list.html
+++ b/functionary/ui/templates/core/package_list.html
@@ -1,37 +1,32 @@
 {% extends "base.html" %}
-
 {% block content %}
-
-<div>
-    {% for package in object_list %}
-    <div class="block">
-        <div class="card">
-            <div class="card-content">
-                <div class="media">
-                    <div class="media-left">
-                        <span class="icon is-large">
-                            <i class="fa fa-2x fa-cubes"></i>
-                        </span>
-                    </div>
-                    <div class="media-content">
-                        <a href="{% url 'ui:package-detail' package.id %}">
-                            <p class="title is-4">
-                                {% if package.display_name %}
-                                {{ package.display_name }} ({{ package.name }})
-                                {% else %}
-                                {{ package.name }}
-                                {% endif %}
-                            </p>
-                        </a>
-                        <p class="subtitle is-6">
-                            {{ package.description }}
-                        </p>
+    <div>
+        {% for package in object_list %}
+            <div class="block">
+                <div class="card">
+                    <div class="card-content">
+                        <div class="media">
+                            <div class="media-left">
+                                <span class="icon is-large">
+                                    <i class="fa fa-2x fa-cubes"></i>
+                                </span>
+                            </div>
+                            <div class="media-content">
+                                <a href="{% url 'ui:package-detail' package.id %}">
+                                    <p class="title is-4">
+                                        {% if package.display_name %}
+                                            {{ package.display_name }} ({{ package.name }})
+                                        {% else %}
+                                            {{ package.name }}
+                                        {% endif %}
+                                    </p>
+                                </a>
+                                {% if package.summary %}<p class="subtitle is-6">{{ package.summary }}</p>{% endif %}
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
+        {% endfor %}
     </div>
-    {% endfor %}
-</div>
-
 {% endblock content %}


### PR DESCRIPTION
This PR adds optional fields for summary for both Packages and Functions. 

The calculator example is updated with the new summary field, the template has a stub for the summary field also. The database has the new optional summary field and the UI has been updated to show the summary on the Package/Function lists as well as the Environment details. Package/Function description is shown on their details page.

The CLI create command was updated to prompt for language if that required option was missing from the command line.
