### PR TITLE
77-Update build endpoint.

### DIFF
--- a/cli/functionary/package.py
+++ b/cli/functionary/package.py
@@ -8,7 +8,7 @@ from rich.text import Text
 
 from .client import get, post
 from .config import get_config_value
-from .utils import format_results
+from .utils import flatten, format_results
 
 
 def create_languages() -> list[str]:
@@ -112,25 +112,29 @@ def publish(ctx, path):
 
 @package_cmd.command()
 @click.pass_context
-@click.option("--id", help="check the status of a specific build with given id")
+@click.option("--id", help="check the status of a specific build with a given id")
 def buildstatus(ctx, id):
     """
-    View status for all builds, or build with specific id
+    View status for all builds, or the build with a specific id
     """
+    title = "Build Status"
     if id:
-        results = get(f"builds/{id}")
-        format_results(
-            [results],
-            title=f"Build: {id}",
-            excluded_fields=["environment", "package_id", "creator_id"],
-        )
+        results = [get(f"builds/{id}")]
+        title = f"Build: {id}"
     else:
         results = get("builds")
-        format_results(
+
+    format_results(
+        flatten(
             results,
-            title="Build Status",
-            excluded_fields=["environment", "package_id", "creator_id"],
-        )
+            object_fields={
+                "package": [("name", "package"), ("id", "Package ID")],
+                "creator": [("username", "creator")],
+            },
+        ),
+        title=title,
+        excluded_fields=["environment"],
+    )
 
 
 @package_cmd.command()

--- a/cli/functionary/package.py
+++ b/cli/functionary/package.py
@@ -119,10 +119,18 @@ def buildstatus(ctx, id):
     """
     if id:
         results = get(f"builds/{id}")
-        format_results([results], title=f"Build: {id}", excluded_fields=["environment"])
+        format_results(
+            [results],
+            title=f"Build: {id}",
+            excluded_fields=["environment", "package_id", "creator_id"],
+        )
     else:
         results = get("builds")
-        format_results(results, title="Build Status", excluded_fields=["environment"])
+        format_results(
+            results,
+            title="Build Status",
+            excluded_fields=["environment", "package_id", "creator_id"],
+        )
 
 
 @package_cmd.command()

--- a/cli/functionary/utils.py
+++ b/cli/functionary/utils.py
@@ -2,6 +2,21 @@ from rich.console import Console
 from rich.table import Table
 
 
+def _get_str_value(value):
+    """Helper function to return a string representation of a value.
+
+    If the passed in value is not a dict, this will return the str() of it.
+    If it is a dict, it will return the str() of the first item that doesn't
+    have a key of 'id', otherwise it will return None.
+    """
+    if not isinstance(value, dict):
+        return str(value)
+
+    # If the value is a dict, find the first key that's not 'id'
+    dictVals = [v for k, v in value.items() if k != "id"]
+    return None if len(dictVals) == 0 else str(dictVals[0])
+
+
 def format_results(results, title="", excluded_fields=[]):
     """
     Helper function to organize table results using Rich
@@ -24,7 +39,7 @@ def format_results(results, title="", excluded_fields=[]):
                 continue
             if first_row:
                 table.add_column(key.capitalize())
-            row_data.append(str(value) if value else None)
+            row_data.append(_get_str_value(value) if value else None)
         table.add_row(*row_data)
         first_row = False
     console.print(table)

--- a/functionary/builder/api/v1/serializers/build.py
+++ b/functionary/builder/api/v1/serializers/build.py
@@ -4,16 +4,32 @@ from rest_framework import serializers
 from builder.models import Build
 
 
+class SimplePackageSerializer(serializers.ModelSerializer):
+    """Serializer that returns the ID and a name field for the object."""
+
+    class Meta:
+        from core.models import Package
+
+        model = Package
+        fields = ["id", "name"]
+
+
+class SimpleUserSerializer(serializers.ModelSerializer):
+    """Serializer that returns the ID and a name field for the object."""
+
+    class Meta:
+        from core.models import User
+
+        model = User
+        fields = ["id", "username"]
+
+
 class BuildSerializer(serializers.ModelSerializer):
     """Basic serializer for the Build model"""
 
-    creator = serializers.SlugRelatedField(
-        many=False, read_only=True, slug_field="username"
-    )
-    package = serializers.SlugRelatedField(
-        many=False, read_only=True, slug_field="name"
-    )
+    creator = SimpleUserSerializer(many=False, read_only=True)
+    package = SimplePackageSerializer(many=False, read_only=True)
 
     class Meta:
         model = Build
-        fields = ["id", "created_at", "updated_at", "package", "creator", "status"]
+        fields = "__all__"

--- a/functionary/builder/api/v1/serializers/build.py
+++ b/functionary/builder/api/v1/serializers/build.py
@@ -2,14 +2,13 @@
 from rest_framework import serializers
 
 from builder.models import Build
+from core.models import Package, User
 
 
 class SimplePackageSerializer(serializers.ModelSerializer):
     """Serializer that returns the ID and a name field for the object."""
 
     class Meta:
-        from core.models import Package
-
         model = Package
         fields = ["id", "name"]
 
@@ -18,8 +17,6 @@ class SimpleUserSerializer(serializers.ModelSerializer):
     """Serializer that returns the ID and a name field for the object."""
 
     class Meta:
-        from core.models import User
-
         model = User
         fields = ["id", "username"]
 

--- a/functionary/builder/api/v1/serializers/build.py
+++ b/functionary/builder/api/v1/serializers/build.py
@@ -7,6 +7,13 @@ from builder.models import Build
 class BuildSerializer(serializers.ModelSerializer):
     """Basic serializer for the Build model"""
 
+    creator = serializers.SlugRelatedField(
+        many=False, read_only=True, slug_field="username"
+    )
+    package = serializers.SlugRelatedField(
+        many=False, read_only=True, slug_field="name"
+    )
+
     class Meta:
         model = Build
-        fields = "__all__"
+        fields = ["id", "created_at", "updated_at", "package", "creator", "status"]

--- a/functionary/builder/api/v1/views/build.py
+++ b/functionary/builder/api/v1/views/build.py
@@ -8,7 +8,7 @@ from ..serializers import BuildSerializer
 class BuildViewSet(EnvironmentReadOnlyModelViewSet):
     """View the status of package builds"""
 
-    queryset = Build.objects.all()
+    queryset = Build.objects.select_related("package", "creator").all()
     serializer_class = BuildSerializer
     permission_classes = [HasEnvironmentPermissionForAction]
     permissioned_model = "Package"

--- a/functionary/builder/utils.py
+++ b/functionary/builder/utils.py
@@ -84,7 +84,7 @@ def initiate_build(
 
         try:
             package_obj = Package.objects.get(
-                environment=environment, name=package_definition.get("names")
+                environment=environment, name=package_definition.get("name")
             )
         except Package.DoesNotExist:
             pass

--- a/functionary/builder/utils.py
+++ b/functionary/builder/utils.py
@@ -112,45 +112,56 @@ def build_package(build_id: UUID):
     os.makedirs(workdir)
 
     build = Build.objects.select_related("environment").get(id=build_id)
+    build.status = Build.IN_PROGRESS
+    build.save()
+
     environment = build.environment
     package_contents = build.resources.package_contents
     package_definition = build.resources.package_definition
 
-    # TODO: This sort of direct access of package_definition should be discouraged, as
-    #       it results in package schema parsing being spread throughout the code. It
-    #       should live in one place and we should call helpers in places like this.
-    name = package_definition["name"]
-    language = package_definition["language"]
-    dockerfile = f"builder/docker/{language}.Dockerfile"
-    image_name = f"{environment.id}/{name}:{build_id}"
+    image_name, dockerfile = build.resources.image_details
     full_image_name = f"{settings.REGISTRY}/{image_name}"
-
-    _extract_package_contents(package_contents, workdir)
-    _load_dockerfile_template(dockerfile, workdir)
-
-    image, build_log = docker_client.images.build(
-        path=workdir,
-        pull=True,
-        forcerm=True,
-        tag=full_image_name,
-    )
-
-    docker_client.images.push(full_image_name)
-
-    logger.debug(f"Cleaning up remnants of build {build_id}")
-    docker_client.images.remove(image.id)
-    shutil.rmtree(workdir)
 
     with transaction.atomic():
         package = _create_package_from_definition(
             package_definition, environment, image_name
         )
-        build.status = Build.COMPLETE
         build.package = package
         build.save()
 
-        # TODO: The Build model should just clean its own resources with post_save hook
-        build.resources.delete()
+    try:
+        # Need to validate the potentially new function schema, but
+        # don't save it until the build has finished.
+        db_functions = _create_functions_from_definition(
+            package_definition.get("functions"), package
+        )
+        _extract_package_contents(package_contents, workdir)
+        _load_dockerfile_template(dockerfile, workdir)
+
+        image, build_log = docker_client.images.build(
+            path=workdir,
+            pull=True,
+            forcerm=True,
+            tag=full_image_name,
+        )
+        docker_client.images.push(full_image_name)
+    except Exception:
+        build.status = Build.ERROR
+        build.save()
+        return
+
+    with transaction.atomic():
+        # Build has succeeded, save all the things now
+        for func in db_functions:
+            func.save()
+        package.image_name = image_name
+        package.save()
+        build.status = Build.COMPLETE
+        build.save()
+
+    logger.debug(f"Cleaning up remnants of build {build_id}")
+    docker_client.images.remove(image.id)
+    shutil.rmtree(workdir)
 
     logger.info(f"Build {build_id} COMPLETE")
 
@@ -193,9 +204,6 @@ def _create_package_from_definition(
     package_obj.summary = package_definition.get("summary")
     package_obj.description = package_definition.get("description")
     package_obj.language = package_definition.get("language")
-    package_obj.image_name = image_name
-
-    _create_functions_from_definition(package_definition.get("functions"), package_obj)
     package_obj.save()
 
     return package_obj
@@ -203,6 +211,7 @@ def _create_package_from_definition(
 
 def _create_functions_from_definition(definitions, package: Package):
     """Creates the functions in the package from the definition file"""
+    db_functions = []
     for function_def in definitions:
         name = function_def.get("name")
         try:
@@ -216,7 +225,9 @@ def _create_functions_from_definition(definitions, package: Package):
         function_obj.schema = _generate_function_schema(
             name, function_def.get("parameters")
         )
-        function_obj.save()
+        db_functions.append(function_obj)
+
+    return db_functions
 
 
 def _generate_function_schema(name: str, parameters) -> str:


### PR DESCRIPTION
This PR updates the build process to save the initial package definition and parses all the functions before starting the build process. This will allow all builds to have a link to a package, regardless of the initial build success/failure. As the build progresses, the build status will be set appropriately and on success, the package is updated with the rest of the new information in the just-built package and the functions are also saved.

The build serializer was updated to return the package name and creator name vs. IDs to display meaningful information for the `buildstatus` command.
