### PR TITLE
#79 - Added fixtures, added script to apply migrations and fixtures

### DIFF
--- a/functionary.code-workspace
+++ b/functionary.code-workspace
@@ -70,7 +70,13 @@
         "type": "shell",
         "command": "docker compose -f ../docker/docker-compose.yml down",
         "problemMatcher": []
-      }
+      },
+      {
+        "label": "functionary: apply migrations and load fixtures",
+        "type": "shell",
+        "command": "docker exec functionary-django ./init.sh",
+        "problemMatcher": []
+      },
     ]
   },
   "extensions": {

--- a/functionary/core/fixtures/bootstrap.yaml
+++ b/functionary/core/fixtures/bootstrap.yaml
@@ -1,0 +1,33 @@
+- model: core.user
+  pk: 1
+  fields:
+    username: admin
+    password: pbkdf2_sha256$390000$K5yDcPRbjMUBEdLLXEstNK$k0ztbdLDFsN6Q6DgCOXH1wVpzpT1+FXIJw44X55AiuU=  #admin
+    first_name: ""
+    last_name: ""
+    email: ""
+    is_active: true
+    created_at: "2022-09-23T14:45:53.705Z"
+    is_staff: true
+    is_superuser: true
+    groups: []
+    user_permissions: []
+
+- model: core.team
+  pk: 29f146e9-4fd0-4cd1-b02d-68c75679c144
+  fields:
+    name: Admin
+
+- model: core.environment
+  pk: 3764e110-2e14-4ab6-a8be-ee7b5b6345d6
+  fields:
+    name: default
+    team: 29f146e9-4fd0-4cd1-b02d-68c75679c144
+    default: true
+
+- model: core.environment
+  pk: 2d113b21-bf1f-4c74-ba12-e37d8f34b72a
+  fields:
+    name: Admin
+    team: 29f146e9-4fd0-4cd1-b02d-68c75679c144
+    default: false

--- a/functionary/init.sh
+++ b/functionary/init.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Init script to execute follow on configurations after the functionary-django container has been launched
+
+
+activate_python_venv() {
+    source $HOME/venv/bin/activate
+}
+
+migrate() {
+    python manage.py migrate
+}
+
+load_fixture() {
+    if [ -n "$1" ]; then
+        python manage.py loaddata $1
+    else
+        echo "No fixture supplied"
+    fi
+}
+
+
+activate_python_venv
+migrate
+load_fixture bootstrap


### PR DESCRIPTION
Closes #79 

This PR adds an init script to the `functionary-django` image, such that the user can execute the script to load a bootstrap fixture into the database. This allows for new users to provision a new admin user, team, and environment, without having to create a new admin user themselves to handcraft the users/team/environments from the admin UI.

## Testing
- If migrations do not already exist: `python manage.py makemigrations`
- If using the vscode workspace, run the `functionary: docker compose up` task 
- If not using the vscode workspace, reference the task commands to grab the docker-compose command
- Once everything comes up, run `docker exec functionary-django ./init.sh` from your terminal
  - Or use the vscode task: "functionary: apply migrations and load fixtures"
- You should see all the migrations get applied to the database, and several objects get installed from the fixture
- You should now be able to log into functionary using the default admin login credentials:
  - Username: `admin`
  - Password: `admin`

## Implementation Notes
- It may make sense to change the Dockerfile's entrypoint to just run an entrypoint script, rather than passing environment vars that have the commands we want to execute
- I am unsure whether or not the fixtures should be automatically run every functionary deployment. I opted for it to be a manually triggered event. If we want it to be automatic, then we should also switch over to the entrypoint script method for the Dockerfiles