### PR TITLE
#82 - Added django debug toolbar

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,6 +4,7 @@ x-environment:
   &environment
   DEBUG: TRUE
   DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-supersecret}
+  DJANGO_SETTINGS_MODULE: functionary.settings.debug
   LOG_LEVEL: DEBUG
   RABBITMQ_USER: ${RABBITMQ_USER:-bugs}
   RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:-wascallywabbit}

--- a/functionary/functionary/settings/__init__.py
+++ b/functionary/functionary/settings/__init__.py
@@ -1,8 +1,0 @@
-from .builder_ import *  # noqa
-from .celery_ import *  # noqa
-from .core_ import *  # noqa
-from .django_ import *  # noqa
-from .logging_ import *  # noqa
-from .rabbitmq_ import *  # noqa
-from .rest_framework_ import *  # noqa
-from .ui_ import *  # noqa

--- a/functionary/functionary/settings/base.py
+++ b/functionary/functionary/settings/base.py
@@ -15,6 +15,14 @@ from pathlib import Path
 
 from django.core.exceptions import ImproperlyConfigured
 
+from .builder_ import *  # noqa
+from .celery_ import *  # noqa
+from .core_ import *  # noqa
+from .logging_ import *  # noqa
+from .rabbitmq_ import *  # noqa
+from .rest_framework_ import *  # noqa
+from .ui_ import *  # noqa
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/functionary/functionary/settings/debug.py
+++ b/functionary/functionary/settings/debug.py
@@ -1,0 +1,18 @@
+import socket
+
+from .base import *  # noqa
+
+DEBUG = True
+
+INSTALLED_APPS += ["debug_toolbar"]
+
+# Note: Order of MIDDLEWARE content matters
+MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
+
+
+# Docker specific method for setting INTERNAL_IPS
+hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
+INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + [
+    "127.0.0.1",
+    "10.0.2.2",
+]

--- a/functionary/functionary/settings/prod.py
+++ b/functionary/functionary/settings/prod.py
@@ -1,0 +1,9 @@
+from .base import *  # noqa
+
+DEBUG = False
+
+ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
+
+
+# TODO: Deploy another container to serve the staticfiles, or use whitenoise
+STATIC_ROOT = f"{BASE_DIR}/static"

--- a/functionary/functionary/urls.py
+++ b/functionary/functionary/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.apps import apps
 from django.contrib import admin
 from django.urls import include, path
 from drf_spectacular.views import (
@@ -42,3 +43,10 @@ urlpatterns = [
     path("ui/", include("ui.urls")),
     path("unicorn/", include("django_unicorn.urls")),
 ]
+
+
+# Add URLs for Django Debug Toolbar if it is an installed app
+if apps.is_installed("debug_toolbar"):
+    urlpatterns += [
+        path("__debug__/", include("debug_toolbar.urls")),
+    ]

--- a/functionary/requirements-dev.in
+++ b/functionary/requirements-dev.in
@@ -9,3 +9,6 @@ isort
 
 # Django formatting
 djlint
+
+# Django debugging
+django-debug-toolbar

--- a/functionary/requirements-dev.txt
+++ b/functionary/requirements-dev.txt
@@ -4,8 +4,11 @@
 #
 #    pip-compile requirements-dev.in
 #
-
-black==22.6.0
+asgiref==3.5.2
+    # via
+    #   -c requirements.txt
+    #   django
+black==22.8.0
     # via -r requirements-dev.in
 click==8.1.3
     # via
@@ -14,11 +17,17 @@ click==8.1.3
     #   djlint
 colorama==0.4.5
     # via djlint
-coverage==6.4.4
+coverage==6.5.0
     # via -r requirements-dev.in
 cssbeautifier==1.14.6
     # via djlint
-djlint==1.12.3
+django==4.1.1
+    # via
+    #   -c requirements.txt
+    #   django-debug-toolbar
+django-debug-toolbar==3.7.0
+    # via -r requirements-dev.in
+djlint==1.18.0
     # via -r requirements-dev.in
 editorconfig==0.12.3
     # via
@@ -30,7 +39,7 @@ html-tag-names==0.1.2
     # via djlint
 html-void-elements==0.1.0
     # via djlint
-importlib-metadata==4.12.0
+importlib-metadata==4.13.0
     # via djlint
 isort==5.10.1
     # via -r requirements-dev.in
@@ -56,13 +65,18 @@ pyyaml==6.0
     # via
     #   -c requirements.txt
     #   djlint
-regex==2022.8.17
+regex==2022.9.13
     # via djlint
 six==1.16.0
     # via
     #   -c requirements.txt
     #   cssbeautifier
     #   jsbeautifier
+sqlparse==0.4.3
+    # via
+    #   -c requirements.txt
+    #   django
+    #   django-debug-toolbar
 tomli==2.0.1
     # via
     #   black

--- a/functionary/requirements.txt
+++ b/functionary/requirements.txt
@@ -20,7 +20,7 @@ cachetools==4.2.4
     # via django-unicorn
 celery==5.2.7
     # via -r requirements.in
-certifi==2022.6.15
+certifi==2022.9.24
     # via requests
 charset-normalizer==2.1.1
     # via requests
@@ -40,30 +40,30 @@ decorator==4.4.2
     # via django-unicorn
 deprecated==1.2.13
     # via redis
-django==4.1
+django==4.1.1
     # via
     #   -r requirements.in
     #   django-unicorn
     #   djangorestframework
     #   drf-spectacular
     #   drf-spectacular-sidecar
-django-unicorn==0.47.0
+django-unicorn==0.48.0
     # via -r requirements.in
-djangorestframework==3.13.1
+djangorestframework==3.14.0
     # via
     #   -r requirements.in
     #   drf-spectacular
 docker==6.0.0
     # via -r requirements.in
-drf-spectacular[sidecar]==0.23.1
+drf-spectacular[sidecar]==0.24.2
     # via -r requirements.in
-drf-spectacular-sidecar==2022.8.1
+drf-spectacular-sidecar==2022.10.1
     # via drf-spectacular
-idna==3.3
+idna==3.4
     # via requests
 inflection==0.5.1
     # via drf-spectacular
-jsonschema==4.14.0
+jsonschema==4.16.0
     # via
     #   -r requirements.in
     #   drf-spectacular
@@ -77,17 +77,17 @@ packaging==21.3
     #   redis
 pika==1.3.0
     # via -r requirements.in
-prompt-toolkit==3.0.30
+prompt-toolkit==3.0.31
     # via click-repl
 psycopg2==2.9.3
     # via -r requirements.in
-pydantic==1.9.2
+pydantic==1.10.2
     # via -r requirements.in
 pyparsing==3.0.9
     # via packaging
 pyrsistent==0.18.1
     # via jsonschema
-pytz==2022.2.1
+pytz==2022.4
     # via
     #   celery
     #   djangorestframework
@@ -105,7 +105,7 @@ six==1.16.0
     # via click-repl
 soupsieve==2.3.2.post1
     # via beautifulsoup4
-sqlparse==0.4.2
+sqlparse==0.4.3
     # via django
 typing-extensions==4.3.0
     # via pydantic
@@ -122,7 +122,7 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
-websocket-client==1.3.3
+websocket-client==1.4.1
     # via docker
 wrapt==1.14.1
     # via deprecated

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [flake8]
 max-line-length = 88
 exclude = functionary/*/migrations/*
+per-file-ignores =
+    # star imported variables may be undefined
+    functionary/functionary/*.py: F405,
 
 [isort]
 profile = black


### PR DESCRIPTION
Closes #82 

This PR adds the Django Debug Toolbar as part of the new debug settings module. Settings modules now inherit from a `base.py` module, which instantiates all the default values. A separate module file can then import all the module-level variables from `base.py` and overwrite them as necessary.

## Testing
- In `docker-compose.yml`, edit the `DJANGO_SETTINGS_MODULE` to point to whichever settings file you want to use
- If using the `debug` settings module, visit Functionary's UI and verify the Django Debug Toolbar is available on the right-side of the screen