### PR TITLE
Issue 98: Add codes to 400 errors

### DIFF
--- a/functionary/builder/exceptions.py
+++ b/functionary/builder/exceptions.py
@@ -1,5 +1,10 @@
-class InvalidPackage(Exception):
+from rest_framework.exceptions import APIException
+
+
+class InvalidPackage(APIException):
     """Exception for when the file provided for a build is not a valid package
     tarball"""
 
-    pass
+    status_code = 400
+    default_detail = "Package is invalid"
+    default_code = "invalid_package"

--- a/functionary/core/api/exceptions.py
+++ b/functionary/core/api/exceptions.py
@@ -12,7 +12,8 @@ def custom_exception_handler(exc, context):
         -context: dictionary containing any extra
          context such as the view currently being handled
     Returns:
-        -response: Either a response object or None
+        -The exception response with the additional error code.
+        Unhandled exceptions return None, resulting in a 500 error
     """
     response = exception_handler(exc, context)
     if response is not None:

--- a/functionary/core/api/exceptions.py
+++ b/functionary/core/api/exceptions.py
@@ -8,12 +8,12 @@ def custom_exception_handler(exc, context):
     to response.
 
     Args:
-        -exc: the exception to handle
-        -context: dictionary containing any extra
-         context such as the view currently being handled
+        exc: the exception to handle
+        context: dictionary containing any extra context such as the view currently
+                 being handled
     Returns:
-        -The exception response with the additional error code.
-        Unhandled exceptions return None, resulting in a 500 error
+        The exception response with the additional error code.  Unhandled exceptions
+        return None, resulting in a 500 error.
     """
     response = exception_handler(exc, context)
     if response is not None:

--- a/functionary/core/api/exceptions.py
+++ b/functionary/core/api/exceptions.py
@@ -1,4 +1,24 @@
 from rest_framework.exceptions import APIException
+from rest_framework.views import exception_handler
+
+
+def custom_exception_handler(exc, context):
+    """
+    Exception handler to add code from custom exceptions
+    to response.
+
+    Args:
+        -exc: the exception to handle
+        -context: dictionary containing any extra
+         context such as the view currently being handled
+    Returns:
+        -response: Either a response object or None
+    """
+    response = exception_handler(exc, context)
+    if response is not None:
+        response.data["code"] = exc.get_codes()
+
+    return response
 
 
 class BadRequest(APIException):
@@ -7,3 +27,27 @@ class BadRequest(APIException):
     status_code = 400
     default_detail = "Request is invalid"
     default_code = "bad_request"
+
+
+class MissingEnvironmentHeader(APIException):
+    """Required environment header is missing"""
+
+    status_code = 400
+    default_detail = "X-Environment-Id or X-Team-Id header must be set"
+    default_code = "missing_env_header"
+
+
+class InvalidEnvironmentHeader(APIException):
+    """Required environment header is present but invalid"""
+
+    status_code = 400
+    default_detail = "X-Environment-Id or X-Team-Id header must be valid"
+    default_code = "invalid_env_header"
+
+
+class InvalidTeamIDHeader(APIException):
+    """Provided TeamID header is invalid"""
+
+    status_code = 400
+    default_detail = "Invalid X-Team-Id header must be set"
+    default_code = "invalid_teamid_header"

--- a/functionary/core/api/mixins.py
+++ b/functionary/core/api/mixins.py
@@ -7,7 +7,11 @@ from rest_framework.exceptions import PermissionDenied
 from core.auth import Permission
 from core.models import Environment, Team
 
-from .exceptions import BadRequest
+from .exceptions import (
+    InvalidEnvironmentHeader,
+    InvalidTeamIDHeader,
+    MissingEnvironmentHeader,
+)
 
 
 class EnvironmentViewMixin:
@@ -34,22 +38,26 @@ class EnvironmentViewMixin:
             try:
                 environment_obj = Environment.objects.get(id=environment_id)
             except (Environment.DoesNotExist, ValidationError):
-                raise BadRequest(f"No environment found with id {environment_id}")
+                raise InvalidEnvironmentHeader(
+                    f"No environment found with id {environment_id}"
+                )
         elif team_id:
             try:
                 team_obj = Team.objects.get(id=team_id)
             except (Team.DoesNotExist, ValidationError):
-                raise BadRequest(f"No team found with id {team_id}")
+                raise InvalidTeamIDHeader(f"No team found with id {team_id}")
 
             try:
                 environment_obj = team_obj.environments.get(default=True)
             except Environment.DoesNotExist:
-                raise BadRequest(
+                raise MissingEnvironmentHeader(
                     f"No default environment for team {team_id}. "
                     "X-Environment-Id header is required."
                 )
         else:
-            raise BadRequest("X-Environment-Id or X-Team-Id header must be set")
+            raise MissingEnvironmentHeader(
+                "X-Environment-Id or X-Team-Id header must be set"
+            )
 
         return environment_obj
 

--- a/functionary/functionary/settings/base/rest_framework_.py
+++ b/functionary/functionary/settings/base/rest_framework_.py
@@ -13,6 +13,7 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "PAGE_SIZE": 25,
+    "EXCEPTION_HANDLER": "core.api.exceptions.custom_exception_handler",
 }
 
 # DRF Spectacular (Swagger/Schema generator) related settings


### PR DESCRIPTION
Closes #98 

First draft of outfitting the 400 errors with error codes by adding a new exception handler (defined in core/api/exceptions.py for use in settings file functionary/settings/base/rest_framework.py). Current exceptions are InvalidPackage (for package yaml errors, defined in builder/exceptions.py for use in builder/api/v1/views/publish.py ), MissingEnvironmentHeader, InvalidEnvironmentHeader, InvalidTeamIDHeader (all defined in core/api/exceptions.py for use in core/api/mixins.py).

I left BadRequest defined in core/api/exceptions.py, but replaced it with the other exceptions wherever else it is in the code. Left error messages mostly the same