### PR TITLE
#79 - Added additional fixture data

### DIFF
--- a/docs/VSCODE.md
+++ b/docs/VSCODE.md
@@ -32,7 +32,9 @@ mostly include autoformatting settings, including format on save to ensure that
 code always adheres to those standards. You can see the various settings in the
 `functionary.code-workspace` file.
 
-## Docker Compose
+## Workspace Tasks
+
+### Docker Compose
 
 There are several processes and dependent services that are required to run in
 order to use functionary. A docker-compose.yml is provided to start and stop all
@@ -46,6 +48,21 @@ listed:
 - "functionary: docker compose down"
 
 Run those as needed to start or stop the entire suite of containers.
+
+### Seed Database
+
+A task is also provided for running migrations and seeding the database with
+some initial data such as teams, environments, and users. This task is listed
+as:
+
+- "functionary: apply migrations and load fixtures"
+
+Once this task is run, a superuser will be available with the username and
+password both set to "admin". Some initial teams, environments, and users with
+various roles are also created. For details on these, view the data in the
+django admin pages, or see the
+[bootstrap.yaml](../functionary/core/fixtures/bootstrap.yaml) containing the
+seed data.
 
 ## Debugging
 

--- a/functionary.code-workspace
+++ b/functionary.code-workspace
@@ -35,6 +35,15 @@
     "prettier.proseWrap": "always",
     "python.analysis.autoImportCompletions": false,
     "python.testing.pytestEnabled": true,
+    "terminal.integrated.env.linux": {
+      "DB_HOST": "localhost",
+      "DEBUG": "TRUE",
+      "DJANGO_SETTINGS_MODULE": "functionary.settings.debug",
+      "DJANGO_SECRET_KEY": "supersecret",
+      "LOG_LEVEL": "DEBUG",
+      "RABBITMQ_USER": "bugs",
+      "RABBITMQ_PASSWORD": "wascallywabbit"
+    },
     "[django-html]": {
       "editor.defaultFormatter": "monosans.djlint"
     },
@@ -79,8 +88,16 @@
         "label": "functionary: apply migrations and load fixtures",
         "type": "shell",
         "command": "docker exec functionary-django ./init.sh",
-        "problemMatcher": []
+        "problemMatcher": [],
+        "dependsOn": "functionary: django up"
       },
+      {
+        "label": "functionary: django up",
+        "type": "shell",
+        "command": "docker compose -f ../docker/docker-compose.yml up --build -d django",
+        "problemMatcher": [],
+        "hide": true
+      }
     ]
   },
   "extensions": {

--- a/functionary/core/fixtures/bootstrap.yaml
+++ b/functionary/core/fixtures/bootstrap.yaml
@@ -1,33 +1,129 @@
+- model: core.environment
+  pk: 2d113b21-bf1f-4c74-ba12-e37d8f34b72a
+  fields:
+    name: prod
+    team: 29f146e9-4fd0-4cd1-b02d-68c75679c144
+    default: false
+- model: core.environment
+  pk: 3764e110-2e14-4ab6-a8be-ee7b5b6345d6
+  fields:
+    name: dev
+    team: 29f146e9-4fd0-4cd1-b02d-68c75679c144
+    default: true
+- model: core.environment
+  pk: 9b999837-9de0-451f-8875-d8da5936b271
+  fields:
+    name: default
+    team: 87bce48d-529a-4578-bbea-fd96d1de91f4
+    default: true
+- model: core.team
+  pk: 29f146e9-4fd0-4cd1-b02d-68c75679c144
+  fields:
+    name: FunctionFoundry
+- model: core.team
+  pk: 87bce48d-529a-4578-bbea-fd96d1de91f4
+  fields:
+    name: ScriptSanctuary
 - model: core.user
   pk: 1
   fields:
     username: admin
-    password: pbkdf2_sha256$390000$K5yDcPRbjMUBEdLLXEstNK$k0ztbdLDFsN6Q6DgCOXH1wVpzpT1+FXIJw44X55AiuU=  #admin
+    password: pbkdf2_sha256$390000$K5yDcPRbjMUBEdLLXEstNK$k0ztbdLDFsN6Q6DgCOXH1wVpzpT1+FXIJw44X55AiuU= # admin
     first_name: ""
     last_name: ""
     email: ""
     is_active: true
-    created_at: "2022-09-23T14:45:53.705Z"
+    last_login: null
+    created_at: 2022-09-23 14:45:53.705000+00:00
     is_staff: true
     is_superuser: true
     groups: []
     user_permissions: []
-
-- model: core.team
-  pk: 29f146e9-4fd0-4cd1-b02d-68c75679c144
+- model: core.user
+  pk: 2
   fields:
-    name: Admin
-
-- model: core.environment
-  pk: 3764e110-2e14-4ab6-a8be-ee7b5b6345d6
+    username: ff-admin
+    password: pbkdf2_sha256$390000$iQENJqHVQKpued6uiIlFzt$B0VEeU8iT6eZ9c/nL/2kxFP9vAtPhzNBY0BUTgwyOAM= # ff-admin
+    first_name: Sam
+    last_name: Administrator
+    email: ""
+    is_active: true
+    last_login: null
+    created_at: 2022-10-13 03:23:36.842002+00:00
+    is_staff: false
+    is_superuser: false
+    groups: []
+    user_permissions: []
+- model: core.user
+  pk: 3
   fields:
-    name: default
+    username: ff-developer
+    password: pbkdf2_sha256$390000$Ln0I2w7hZPWvhuOeBx8YZP$jYjOru8pfnvbrh6WKiyUjeRFX6gfGMDGBk+xOIbmTX4= # ff-developer
+    first_name: Joe
+    last_name: Developer
+    email: ""
+    is_active: true
+    last_login: null
+    created_at: 2022-10-13 03:24:08.235549+00:00
+    is_staff: false
+    is_superuser: false
+    groups: []
+    user_permissions: []
+- model: core.user
+  pk: 4
+  fields:
+    username: ff-operator
+    password: pbkdf2_sha256$390000$bz4pPoESJWGPxxyif3wcCT$gBt1ULCzDFx1Cm1wviODIYJzBSZ1nGfLH9KjgWV0/FM= # ff-operator
+    first_name: Jane
+    last_name: Operator
+    email: ""
+    is_active: true
+    last_login: null
+    created_at: 2022-10-13 03:24:28.528741+00:00
+    is_staff: false
+    is_superuser: false
+    groups: []
+    user_permissions: []
+- model: core.user
+  pk: 5
+  fields:
+    username: ff-readonly
+    password: pbkdf2_sha256$390000$rdJdNLYRBpUG1cTFRcT3a3$7Ct7bOn+P5YRQ+zC8iJvtb8xcIjLbovQfTf4yfDha50= # ff-readonly
+    first_name: Mike
+    last_name: Readonly
+    email: ""
+    is_active: true
+    last_login: null
+    created_at: 2022-10-13 03:24:59.841908+00:00
+    is_staff: false
+    is_superuser: false
+    groups: []
+    user_permissions: []
+- model: core.teamuserrole
+  pk: 1
+  fields:
+    user: 2
+    role: ADMIN
+    updated_at: 2022-10-13 03:25:11.945677+00:00
     team: 29f146e9-4fd0-4cd1-b02d-68c75679c144
-    default: true
-
-- model: core.environment
-  pk: 2d113b21-bf1f-4c74-ba12-e37d8f34b72a
+- model: core.teamuserrole
+  pk: 2
   fields:
-    name: Admin
+    user: 5
+    role: READ_ONLY
+    updated_at: 2022-10-13 03:25:22.561696+00:00
     team: 29f146e9-4fd0-4cd1-b02d-68c75679c144
-    default: false
+- model: core.environmentuserrole
+  pk: 1
+  fields:
+    user: 3
+    role: DEVELOPER
+    updated_at: 2022-10-13 03:25:47.438761+00:00
+    environment: 3764e110-2e14-4ab6-a8be-ee7b5b6345d6
+- model: core.environmentuserrole
+  pk: 2
+  fields:
+    user: 4
+    role: OPERATOR
+    updated_at: 2022-10-13 03:25:56.915799+00:00
+    environment: 2d113b21-bf1f-4c74-ba12-e37d8f34b72a

--- a/functionary/init.sh
+++ b/functionary/init.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-# Init script to execute follow on configurations after the functionary-django container has been launched
+# Init script to execute follow on configurations after the functionary-django
+# container has been launched. Intended for use in the VSCode-enabled dev
+# workflow.
 
 
 activate_python_venv() {


### PR DESCRIPTION
This PR builds on the initial work for #79.  It fleshes out the fixture data so that it now contains

* Two separate Teams:
  * FunctionFoundry, containing a dev and prod environment
  * ScriptSanctuary, containing just a default environment
* A bunch of users with various roles for FunctionFoundry:
  * admin: The same superuser account that existed before
  * ff-admin: admin role for the entire team
  * ff-readonly: read only role for the entire team
  * ff-developer: developer role for dev
  * ff-operator: operator role for prod
* The password for all users is the same as their username

The idea is just to have a handful of accounts ready to go with different permissions to easily test or demonstrate access control in various areas.

Additionally, I added a dependent task that starts the django container so that it's now possible to run the "apply migrations and load fixtures" task even if the containers aren't already running.  In that situation the necessary container will be started for you and then the migration task will run.