### PR TITLE
#95 - Added consistent formatting to all loggers

### DIFF
--- a/functionary/builder/celery.py
+++ b/functionary/builder/celery.py
@@ -1,5 +1,14 @@
+from logging.config import dictConfig
+
 from celery import Celery
+from celery.signals import setup_logging
+from django.conf import settings
 
 app = Celery("builder")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.conf.task_default_queue = "builder"
+
+
+@setup_logging.connect
+def config_loggers(*args, **kwargs):
+    dictConfig(settings.CELERY_LOGGING)

--- a/functionary/core/celery.py
+++ b/functionary/core/celery.py
@@ -1,5 +1,14 @@
+from logging.config import dictConfig
+
 from celery import Celery
+from celery.signals import setup_logging
+from django.conf import settings
 
 app = Celery("core", include=["core.utils.tasking"])
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.conf.task_default_queue = "core"
+
+
+@setup_logging.connect
+def config_loggers(*args, **kwargs):
+    dictConfig(settings.CELERY_LOGGING)

--- a/functionary/core/utils/tasking.py
+++ b/functionary/core/utils/tasking.py
@@ -128,9 +128,9 @@ def run_scheduled_task(scheduled_task_id: str) -> None:
 def _update_task_status(task: Task, status: int) -> None:
     match status:
         case 0:
-            task.status = "COMPLETE"
+            task.status = Task.COMPLETE
         case _:
-            task.status = "ERROR"
+            task.status = Task.ERROR
 
     task.save()
 

--- a/runner/runner.py
+++ b/runner/runner.py
@@ -1,12 +1,11 @@
 import logging
+import sys
 from os import getenv
 
 from runner import Listener, Worker
 
 LOG_LEVEL = getenv("LOG_LEVEL", "INFO")
-logging.basicConfig(level=LOG_LEVEL)
-logging.getLogger("pika").propagate = False
-logging.getLogger("amqp").propagate = False
+logging.basicConfig(stream=sys.stdout, level=LOG_LEVEL)
 
 
 def spawn_listener() -> Listener:

--- a/runner/runner/celery.py
+++ b/runner/runner/celery.py
@@ -14,6 +14,8 @@ from celery import Celery
 from celery.apps.worker import Worker
 from celery.signals import setup_logging
 
+from .logging_configs import CELERY_LOGGING, LOG_LEVEL
+
 RABBITMQ_HOST = getenv("RABBITMQ_HOST", "localhost")
 RABBITMQ_PORT = getenv("RABBITMQ_PORT", 5672)
 RABBITMQ_USER = getenv("RABBITMQ_USER")
@@ -23,33 +25,6 @@ RABBITMQ_VHOST = getenv("RUNNER_DEFAULT_VHOST", "public")
 WORKER_CONCURRENCY = cpu_count()
 WORKER_HOSTNAME = "worker"
 WORKER_NAME = f"celery@{WORKER_HOSTNAME}"
-
-LOG_LEVEL = getenv("LOG_LEVEL", "INFO").upper()
-
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "simple": {"format": "[{levelname:<8}] {asctime:<24} {message}", "style": "{"},
-    },
-    "handlers": {
-        "console": {
-            "level": LOG_LEVEL,
-            "class": "logging.StreamHandler",
-            "formatter": "simple",
-        },
-    },
-    "loggers": {
-        "celery": {
-            "handlers": ["console"],
-            "propagate": False,
-        },
-        "kombu": {
-            "handlers": ["console"],
-            "propagate": False,
-        },
-    },
-}
 
 
 app = Celery(
@@ -64,7 +39,7 @@ app = Celery(
 
 @setup_logging.connect
 def config_loggers(*args, **kwargs):
-    dictConfig(LOGGING)
+    dictConfig(CELERY_LOGGING)
 
 
 if __name__ == "__main__":

--- a/runner/runner/handlers.py
+++ b/runner/runner/handlers.py
@@ -49,7 +49,7 @@ def _run_task(task):
     variables = task.get("variables")
     run_command = ["--function", function, "--parameters", parameters]
 
-    logging.info("Running %s from package %s", function, package)
+    logger.info("Running %s from package %s", function, package)
     docker_client = docker.from_env()
     try:
         container = docker_client.containers.run(

--- a/runner/runner/listener.py
+++ b/runner/runner/listener.py
@@ -1,5 +1,6 @@
 from json import loads
 from logging import getLogger
+from logging.config import dictConfig
 from time import sleep
 
 from celery import chain
@@ -9,9 +10,11 @@ from pika.spec import Basic, BasicProperties
 
 from .celery import WORKER_CONCURRENCY, WORKER_NAME, app
 from .handlers import publish_result, pull_image, run_task
+from .logging_configs import LISTENER_LOGGING
 from .messaging import build_connection
 
 logger = getLogger(__name__)
+dictConfig(LISTENER_LOGGING)
 
 WAIT_FOR_AVAILABLE_WORKER_DELAY = 2
 WAIT_FOR_MESSAGE_DELAY = 0.5

--- a/runner/runner/logging_configs.py
+++ b/runner/runner/logging_configs.py
@@ -26,7 +26,6 @@ handlers = {
 }
 
 
-# Celery Logging Config
 CELERY_LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -35,24 +34,21 @@ CELERY_LOGGING = {
     "loggers": {
         "celery": {"handlers": ["console"], "propagate": False},
         "docker": {"propagate": False},
-        "kombu": {"handlers": ["console"], "propagate": False},
+        "kombu": {"propagate": False},
         "urllib3": {"propagate": False},
     },
 }
 
-
-# Django Logging Config
-LOGGING = {
+LISTENER_LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": formatters,
     "handlers": handlers,
     "loggers": {
         "amqp": {"propagate": False},
-        "core": {"handlers": ["console"], "propagate": False},
-        "django": {"handlers": ["console"], "propagate": False},
         "docker": {"propagate": False},
         "pika": {"propagate": False},
+        "runner": {"handlers": ["console"], "propagate": False},
         "urllib3": {"propagate": False},
     },
 }


### PR DESCRIPTION
Closes #95 

This PR adds a consistent format for logs produced by the Django and Celery applications. 

## Introduced Changes 
- Added logging dictionary config in `functionary/settings/base/__init__.py` that configures the various loggers
- Added logging dictionary config in `functionary/settings/base/celery_.py` that configures the Celery logger 
- Added environment variable to disable the `Pika` logs in the `runner-worker` and `runner-listener`

## Testing
- Spin up Functionary
- Inspect the logs of any Functionary containers
- Verify the outputted log format matches the logging format defined in the `LOGGING` config
  - For Django apps: `functionary/settings/base/__init__.py`
  - For Celery: `functionary/settings/base/celery_.py` or in the `celery.py` file that defines the Celery app