### PR TITLE
#92 - Runner now uses filesystem broker instead of redis

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.5"
 x-environment:
   &environment
   DEBUG: TRUE
+  BROKER_WORKDIR: /tmp
   DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-supersecret}
   DJANGO_SETTINGS_MODULE: functionary.settings.debug
   LOG_LEVEL: DEBUG
@@ -118,7 +119,6 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - rabbitmq
-      - redis
   database:
     image: postgres:latest
     container_name: functionary-database

--- a/runner/.vscode/.debug.env
+++ b/runner/.vscode/.debug.env
@@ -1,3 +1,4 @@
 LOG_LEVEL = "DEBUG"
 RABBITMQ_USER = "bugs"
 RABBITMQ_PASSWORD = "wascallywabbit"
+BROKER_WORKDIR = "/tmp"

--- a/runner/runner.py
+++ b/runner/runner.py
@@ -8,14 +8,25 @@ logging.basicConfig(level=LOG_LEVEL)
 logging.getLogger("pika").propagate = False
 
 
-def spawn_listener():
+def setup_broker_dir() -> None:
+    broker_workdir = os.getenv("BROKER_WORKDIR", "/tmp")
+    broker_workdir_path = os.path.join(broker_workdir, "broker")
+    try:
+        if not os.path.exists(broker_workdir_path):
+            os.makedirs(os.path.join(broker_workdir_path))
+    except PermissionError:
+        raise PermissionError(
+            f'You do not have permission to create {broker_workdir_path}'
+        )
+
+def spawn_listener() -> Listener:
     listener = Listener()
     listener.start()
 
     return listener
 
 
-def spawn_worker():
+def spawn_worker() -> Worker:
     worker = Worker()
     worker.start()
 
@@ -23,6 +34,7 @@ def spawn_worker():
 
 
 if __name__ == "__main__":
+    setup_broker_dir()
     listener = spawn_listener()
     worker = spawn_worker()
 


### PR DESCRIPTION
Closes #92 

This PR removes the Redis dependency from the Runner by using the Filesystem broker for Celery.

## Introduced Changes
- Celery App for the Runner uses the Filesystem broker instead of the Redis broker

## Testing
- Start Functionary
- Inspect container logs for `functionary_runner`. In the config section of the Celery startup message, it should say Celery is using `filesystem://localhost//` for the `transport` variable
  - You should also see Celery repeatedly checking for new tasks every second
- Run a Functionary function to verify function gets executed as expected