### PR TITLE
#106: Remove milliseconds from datetime display

### DIFF
--- a/cli/functionary/utils.py
+++ b/cli/functionary/utils.py
@@ -56,9 +56,7 @@ def _fix_datetime_display(value):
     Returns:
         value as a string representing datetime value without milliseconds
     """
-    value = datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f%z").replace(
-        microsecond=0
-    )
+    value = datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f%z")
     return value.strftime("%Y-%m-%d %H:%M:%S%Z")
 
 

--- a/cli/functionary/utils.py
+++ b/cli/functionary/utils.py
@@ -56,8 +56,8 @@ def _fix_datetime_display(value):
     Returns:
         value as a string representing datetime value without milliseconds
     """
-    value = datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ").replace(
-        tzinfo=datetime.timezone.utc, microsecond=0
+    value = datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f%z").replace(
+        microsecond=0
     )
     return value.strftime("%Y-%m-%d %H:%M:%S%Z")
 
@@ -85,7 +85,7 @@ def format_results(results, title="", excluded_fields=[]):
                 continue
             if first_row:
                 table.add_column(key.capitalize())
-            if "_at" in key:
+            if key.endswith("_at"):
                 value = _fix_datetime_display(value)
             row_data.append(str(value) if value else None)
         table.add_row(*row_data)

--- a/cli/functionary/utils.py
+++ b/cli/functionary/utils.py
@@ -1,3 +1,5 @@
+import datetime
+
 from rich.console import Console
 from rich.table import Table
 
@@ -45,6 +47,21 @@ def flatten(results, object_fields):
     return new_results
 
 
+def _fix_datetime_display(value):
+    """
+    Helper function for format_results to remove milliseconds from datetime
+
+    Args:
+        value: string representing datetime value
+    Returns:
+        value as a string representing datetime value without milliseconds
+    """
+    value = datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ").replace(
+        tzinfo=datetime.timezone.utc, microsecond=0
+    )
+    return value.strftime("%Y-%m-%d %H:%M:%S%Z")
+
+
 def format_results(results, title="", excluded_fields=[]):
     """
     Helper function to organize table results using Rich
@@ -68,6 +85,8 @@ def format_results(results, title="", excluded_fields=[]):
                 continue
             if first_row:
                 table.add_column(key.capitalize())
+            if "_at" in key:
+                value = _fix_datetime_display(value)
             row_data.append(str(value) if value else None)
         table.add_row(*row_data)
         first_row = False


### PR DESCRIPTION
Closes #106 

Makes datetime objects present in cli tables come out formatted like '2022-10-13 19:36:18UTC'