### PR TITLE
Issue 124: Add build viewing to UI

### DIFF
--- a/functionary/ui/templates/base.html
+++ b/functionary/ui/templates/base.html
@@ -87,6 +87,12 @@
                     </ul>
                     <ul class="menu-list block">
                         <li class="menu-item">
+                            <a href="{% url 'ui:build-list' %}">
+                                <span class="icon has-text-info"><i class="fa fa-lg fa-wrench"></i></span>
+                                &nbsp;Builds
+                            </a>
+                        </li>
+                        <li class="menu-item">
                             <a href="{% url 'ui:package-list' %}">
                                 <span class="icon has-text-info"><i class="fa fa-lg fa-cubes"></i></span>
                                 &nbsp;Packages

--- a/functionary/ui/templates/builder/build_detail.html
+++ b/functionary/ui/templates/builder/build_detail.html
@@ -7,7 +7,7 @@
                     <a href="{% url 'ui:build-list' %}">Build List</a>
                 </li>
                 <li class="is-active">
-                    <a href="#">{{ object.id }}</a>
+                    <a href="#">{{ object.package }}</a>
                 </li>
             </ul>
         </nav>
@@ -16,7 +16,7 @@
         <div class="block">
             <h1 class="title is-1">
                 <span class="icon"><i class="fa fa-wrench"></i></span>&nbsp;&nbsp;
-                {{ object.id }}
+                {{ object.package }}
             </h1>
         </div>
         <div class="column has-addons">
@@ -44,22 +44,16 @@
                     <span class="ml-4">{{ object.status }}</span>
                 </div>
             {% endif %}
-            {% if object.environment %}
+            {% if object.id %}
                 <div class="field">
-                    <label class="label" for="desc">Environment:</label>
-                    <span class="ml-4">{{ object.environment }}</span>
-                </div>
-            {% endif %}
-            {% if object.package %}
-                <div class="field">
-                    <label class="label" for="desc">Package:</label>
-                    <span class="ml-4">{{ object.package }}</span>
+                    <label class="label" for="desc">Build Id:</label>
+                    <span class="ml-4">{{ object.id }}</span>
                 </div>
             {% endif %}
             {% if build_log.log %}
                 <div class="field">
                     <label class="label" for="desc">Build Log:</label>
-                    <span class="ml-4">{{ build_log.log }}</span>
+                    <pre class="ml-4">{{ build_log.log }}</pre>
                 </div>
             {% endif %}
         </div>

--- a/functionary/ui/templates/builder/build_detail.html
+++ b/functionary/ui/templates/builder/build_detail.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+{% block content %}
+    <div class="column is-full">
+        <nav class="breadcrumb has-arrow-separator" aria-label="breadcrumbs">
+            <ul>
+                <li>
+                    <a href="{% url 'ui:build-list' %}">Build List</a>
+                </li>
+                <li class="is-active">
+                    <a href="#">{{ object.id }}</a>
+                </li>
+            </ul>
+        </nav>
+    </div>
+    <div class="column">
+        <div class="block">
+            <h1 class="title is-1">
+                <span class="icon"><i class="fa fa-wrench"></i></span>&nbsp;&nbsp;
+                {{ object.id }}
+            </h1>
+        </div>
+        <div class="column has-addons">
+            {% if object.created_at %}
+                <div class="field">
+                    <label class="label" for="desc">Created At:</label>
+                    <span class="ml-4">{{ object.created_at }}</span>
+                </div>
+            {% endif %}
+            {% if object.updated_at %}
+                <div class="field">
+                    <label class="label" for="desc">Updated At:</label>
+                    <span class="ml-4">{{ object.updated_at }}</span>
+                </div>
+            {% endif %}
+            {% if object.creator %}
+                <div class="field">
+                    <label class="label" for="desc">Creator:</label>
+                    <span class="ml-4">{{ object.creator }}</span>
+                </div>
+            {% endif %}
+            {% if object.status %}
+                <div class="field">
+                    <label class="label" for="desc">Status:</label>
+                    <span class="ml-4">{{ object.status }}</span>
+                </div>
+            {% endif %}
+            {% if object.environment %}
+                <div class="field">
+                    <label class="label" for="desc">Environment:</label>
+                    <span class="ml-4">{{ object.environment }}</span>
+                </div>
+            {% endif %}
+            {% if object.package %}
+                <div class="field">
+                    <label class="label" for="desc">Package:</label>
+                    <span class="ml-4">{{ object.package }}</span>
+                </div>
+            {% endif %}
+            {% if build_log.log %}
+                <div class="field">
+                    <label class="label" for="desc">Build Log:</label>
+                    <span class="ml-4">{{ build_log.log }}</span>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+{% endblock content %}

--- a/functionary/ui/templates/builder/build_list.html
+++ b/functionary/ui/templates/builder/build_list.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+    <div>
+        {% for build in object_list %}
+            <div class="block">
+                <div class="card">
+                    <div class="card-content">
+                        <div class="media">
+                            <div class="media-left">
+                                <span class="icon is-large">
+                                    <i class="fa fa-2x fa-wrench"></i>
+                                </span>
+                            </div>
+                            <div class="media-content">
+                                <a href="{% url 'ui:build-detail' build.id %}">
+                                    <p class="title is-4">{{ build.id }}</p>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+{% endblock content %}

--- a/functionary/ui/templates/builder/build_list.html
+++ b/functionary/ui/templates/builder/build_list.html
@@ -13,8 +13,15 @@
                             </div>
                             <div class="media-content">
                                 <a href="{% url 'ui:build-detail' build.id %}">
-                                    <p class="title is-4">{{ build.id }}</p>
+                                    <p class="title is-4">{{ build.package }}</p>
                                 </a>
+                                <p class="subtitle is-6">
+                                    <span class="is-size-6 has-text-weight-normal">Status: {{ build.status }}</span>
+                                    <br/>
+                                    <span><i class="fa fa-user"></i>&nbsp;{{ build.creator.username }}</span>
+                                    <br/>
+                                    <span class="is-size-6 has-text-weight-normal">(Created at {{ build.created_at }})</span>
+                                </p>
                             </div>
                         </div>
                     </div>

--- a/functionary/ui/urls.py
+++ b/functionary/ui/urls.py
@@ -2,12 +2,22 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import include, path
 
-from .views import environments, functions, home, packages, tasks, teams
+from .views import builds, environments, functions, home, packages, tasks, teams
 
 app_name = "ui"
 
 urlpatterns = [
     path("", home.home, name="home"),
+    path(
+        "build_list/",
+        (builds.BuildListView.as_view()),
+        name="build-list",
+    ),
+    path(
+        "build/<uuid:pk>",
+        (builds.BuildDetailView.as_view()),
+        name="build-detail",
+    ),
     path(
         "environment_list/",
         (environments.EnvironmentListView.as_view()),

--- a/functionary/ui/views/builds.py
+++ b/functionary/ui/views/builds.py
@@ -1,0 +1,20 @@
+from builder.models import Build, BuildLog
+
+from .view_base import (
+    PermissionedEnvironmentDetailView,
+    PermissionedEnvironmentListView,
+)
+
+
+class BuildListView(PermissionedEnvironmentListView):
+    model = Build
+    order_by_fields = ["id"]
+
+
+class BuildDetailView(PermissionedEnvironmentDetailView):
+    model = Build
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["build_log"] = BuildLog.objects.filter(build=context["object"])[0]
+        return context

--- a/functionary/ui/views/builds.py
+++ b/functionary/ui/views/builds.py
@@ -1,4 +1,6 @@
-from builder.models import Build, BuildLog
+from django.core.exceptions import ObjectDoesNotExist
+
+from builder.models import Build
 
 from .view_base import (
     PermissionedEnvironmentDetailView,
@@ -8,7 +10,7 @@ from .view_base import (
 
 class BuildListView(PermissionedEnvironmentListView):
     model = Build
-    order_by_fields = ["id"]
+    order_by_fields = ["created_at"]
 
 
 class BuildDetailView(PermissionedEnvironmentDetailView):
@@ -16,5 +18,8 @@ class BuildDetailView(PermissionedEnvironmentDetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["build_log"] = BuildLog.objects.filter(build=context["object"])[0]
+        try:
+            context["build_log"] = context["object"].buildlog
+        except ObjectDoesNotExist:
+            context["build_log"] = None
         return context


### PR DESCRIPTION
Closes #124 

Added two new templates: functionary/ui/templates/builder/build_list.html and functionary/ui/templates/builder/build_detail.html. Two new corresponding views to go with them in functionary/ui/views/builds.py. Updated functionary/ui/urls.py with routes to the new views.

The one minor thing I saw to add was making the newline characters in the log print out. The editor didn't seem to like it style wise if I did it using inline styles on the html page, but the css file involved here looks like a ton of preset stuff.