### PR TITLE
#114 - Scheduled Tasking frontend support

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -78,6 +78,26 @@ services:
       - ../functionary:/app
     depends_on:
       - rabbitmq
+  scheduler:
+    build:
+      context: ../functionary
+      dockerfile: ../docker/dev.Dockerfile
+      args:
+        uid: ${UID:-1000}
+    image: functionary_django
+    container_name: functionary-scheduler
+    command: run_scheduler
+    environment:
+      <<: *environment
+    networks:
+      - functionary-network
+    ports:
+      - 5684:5684
+    volumes:
+      - ../functionary:/app
+    depends_on:
+      - rabbitmq
+      - database
   build-worker:
     build:
       context: ../functionary

--- a/functionary/core/utils/scheduling.py
+++ b/functionary/core/utils/scheduling.py
@@ -1,0 +1,246 @@
+from json import dumps
+
+from django.core.exceptions import ValidationError
+from django.forms import Widget
+from django.http import HttpResponseNotFound, QueryDict
+from django_celery_beat.models import CrontabSchedule, PeriodicTask
+from django_celery_beat.validators import (
+    crontab_validator,
+    day_of_month_validator,
+    day_of_week_validator,
+    hour_validator,
+    minute_validator,
+    month_of_year_validator,
+)
+
+from core.models import Environment, Function, ScheduledTask
+from ui.forms.tasks import _field_mapping, _get_param_type, _prepare_initial_value
+
+
+def create_crontab_schedule(crontab_fields: dict) -> CrontabSchedule:
+    """Creates and returns a crontab schedule
+
+    If the submitted crontab schedule already exists, returns
+    the existing crontab schedule. Otherwise, creates and
+    returns a new crontab schedule.
+
+    Args:
+        crontab_fields: A dict that contains the crontab fields described in
+            the SchdeuledTaskForm.
+
+    Returns:
+        CronTabSchedule: The new, or existing, crontab schedule
+    """
+    minute = crontab_fields["scheduled_minute"]
+    hour = crontab_fields["scheduled_hour"]
+    day_of_week = crontab_fields["scheduled_day_of_week"]
+    day_of_month = crontab_fields["scheduled_day_of_month"]
+    month_of_year = crontab_fields["scheduled_month_of_year"]
+    crontab_str = f"{minute} {hour} {day_of_month} {month_of_year} {day_of_week}"
+    try:
+        crontab_validator(crontab_str)
+        crontab_schedule, _ = CrontabSchedule.objects.get_or_create(
+            minute=minute,
+            hour=hour,
+            day_of_week=day_of_week,
+            day_of_month=day_of_month,
+            month_of_year=month_of_year,
+        )
+        return crontab_schedule
+    except ValueError as err:
+        print(f"Invalid Crontab. {err}")
+        raise ValueError(err)
+
+
+def create_periodic_task(
+    data: QueryDict, scheduled_task: ScheduledTask
+) -> PeriodicTask:
+    """Create a new periodic task
+
+    Creates a new periodic task and assigns it to the given scheduled task.
+
+    Args:
+        data: A QueryDict that contains the ScheduledTaskForm data
+        scheduled_task: The ScheduledTask object
+
+    Returns:
+        PeriodicTask: The newly created PeriodicTask
+    """
+    crontab_schedule = create_crontab_schedule(data)
+
+    periodic_task = PeriodicTask.objects.create(
+        crontab=crontab_schedule,
+        name=data["name"],
+        task="core.utils.tasking.run_scheduled_task",
+        args=dumps([f"{scheduled_task.id}"]),
+        enabled=False,
+    )
+
+    scheduled_task.periodic_task = periodic_task
+    scheduled_task.save()
+
+    return periodic_task
+
+
+def get_function(function_id: str, env: Environment) -> Function:
+    """Return Function given the function id and environment
+
+    Simple helper function for retrieving the Function object given the
+    function id string and environment object of the session. If the
+    function is not available in the environment, or the function simply does
+    not exist, return an HttpResponse
+
+    Args:
+        function_id: The Function objects id as a string
+        env: The Environment object
+
+    Returns either:
+        Function: The function object if it exists within the environment
+        HttpResponseNotFound: A HttpResponseNotFound response if the function does
+            not exist at all or in the environment
+    """
+    try:
+        if (
+            function := Function.objects.filter(
+                id=function_id, package__environment=env
+            ).first()
+        ) is None:
+            return HttpResponseNotFound("Unknown Function submitted.")
+        return function
+    except ValidationError:
+        return HttpResponseNotFound("Unknown Function submitted.")
+
+
+def get_parameters(func: Function, parameter_values: dict = None) -> list[dict]:
+    """Returns the parameters for a given function
+
+    Returns a list of dictionaries containing all the parameters
+    for a given function. If the parameter_values argument is passed,
+    the default values of the parameters will be overriden.
+
+    Args:
+        func: The Function object whose parameters you want to get
+        parameter_values: The optional dictionary that will override the
+            parameter's default values
+
+    Returns:
+        parameters: A list of parameters. Each parameter is a dictionary.
+    """
+
+    parameters = []
+    for param, value in func.schema["properties"].items():
+        initial = value.get("default", None)
+        req = initial is None
+        param_type = _get_param_type(value)
+        field_class, widget = _field_mapping.get(param_type, (None, None))
+
+        if not field_class:
+            raise ValueError(f"Unknown field type for {param}: {param_type}")
+
+        initial_value = None
+        if parameter_values is None:
+            initial_value = _prepare_initial_value(param_type, initial)
+        else:
+            initial_value = parameter_values.get(param, initial)
+
+        widget: Widget = field_class.widget()
+        if param_type != "boolean":
+            widget.attrs = {"class": "input is-medium is-fullwidth"}
+        else:
+            widget.attrs = {"class": "input is-medium", "type": "checkbox"}
+
+        parameter = {
+            "label": value["title"],
+            "label_suffix": param_type,
+            "initial": initial_value,
+            "required": req,
+            "help_text": value.get("description", None),
+            "widget": widget.render(value["title"], initial_value),
+        }
+        parameters.append(parameter)
+
+    return parameters
+
+
+def is_valid_scheduled_minute(field: str) -> bool:
+    try:
+        minute_validator(field)
+        return True
+    except Exception:
+        return False
+
+
+def is_valid_scheduled_hour(field: str) -> bool:
+    try:
+        hour_validator(field)
+        return True
+    except Exception:
+        return False
+
+
+def is_valid_scheduled_day_of_week(field: str) -> bool:
+    try:
+        day_of_week_validator(field)
+        return True
+    except Exception:
+        return False
+
+
+def is_valid_scheduled_day_of_month(field: str) -> bool:
+    try:
+        day_of_month_validator(field)
+        return True
+    except Exception:
+        return False
+
+
+def is_valid_scheduled_month_of_year(field: str) -> bool:
+    try:
+        month_of_year_validator(field)
+        return True
+    except Exception:
+        return False
+
+
+def update_status(status: str, scheduled_task: ScheduledTask) -> None:
+    """Updates the status of the given scheduled task
+
+    Given a new status string, update the given scheduled task's status
+    to the new status, and perform that status's operation on the scheduled task.
+
+    Args:
+        status: A string that should be equivalent to any of the statuses defined
+            in the ScheduledTask model
+        scheduled_task: The ScheduledTask object whose status should be updated.
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If the given status is not a valid status, raises a ValueError.
+    """
+    match status:
+        case ScheduledTask.ACTIVE:
+            scheduled_task.activate()
+        case ScheduledTask.PAUSED:
+            scheduled_task.pause()
+        case ScheduledTask.ARCHIVED:
+            scheduled_task.archive()
+        case _:
+            raise ValueError("Unknown status given.")
+
+
+def update_crontab(fields: dict, scheduled_task: ScheduledTask) -> None:
+    """Helper function that updates a ScheduledTask's crontab schedule
+
+    Args:
+        fields: A dictionary containing the crontab fields
+        scheduled_task: The ScheduledTask object whose crontab schedule should
+            be updated
+
+    Returns:
+        None
+    """
+    crontab_schedule = create_crontab_schedule(fields)
+    scheduled_task.periodic_task.crontab = crontab_schedule
+    scheduled_task.periodic_task.save()

--- a/functionary/ui/forms/tasks.py
+++ b/functionary/ui/forms/tasks.py
@@ -1,5 +1,6 @@
 import json
 
+from django.db.models.query import QuerySet
 from django.forms import (
     BooleanField,
     CharField,
@@ -9,9 +10,21 @@ from django.forms import (
     Form,
     IntegerField,
     JSONField,
+    ModelForm,
     Textarea,
+    ValidationError,
 )
 from django.forms.widgets import DateInput, DateTimeInput
+from django.urls import reverse
+from django_celery_beat.validators import (
+    day_of_month_validator,
+    day_of_week_validator,
+    hour_validator,
+    minute_validator,
+    month_of_year_validator,
+)
+
+from core.models import Environment, Function, ScheduledTask
 
 
 class HTMLDateInput(DateInput):
@@ -83,6 +96,10 @@ def _prepare_initial_value(param_type, initial):
     return None
 
 
+def get_available_functions(env: Environment) -> QuerySet[Function]:
+    return Function.objects.filter(package__environment=env)
+
+
 class TaskParameterForm(Form):
     template_name = "forms/task_parameters.html"
 
@@ -115,3 +132,110 @@ class TaskParameterForm(Form):
             if param_type != "boolean":
                 field.widget.attrs.update({"class": "input"})
             self.fields[param] = field
+
+
+class ScheduledTaskForm(ModelForm):
+    scheduled_minute = CharField(
+        max_length=60 * 4, label="Minute", initial="*", validators=[minute_validator]
+    )
+    scheduled_hour = CharField(
+        max_length=24 * 4, label="Hour", initial="*", validators=[hour_validator]
+    )
+    scheduled_day_of_week = CharField(
+        max_length=64,
+        label="Day of Week",
+        initial="*",
+        validators=[day_of_week_validator],
+    )
+    scheduled_day_of_month = CharField(
+        max_length=31 * 4,
+        label="Day of Month",
+        initial="*",
+        validators=[day_of_month_validator],
+    )
+    scheduled_month_of_year = CharField(
+        max_length=64,
+        label="Month of Year",
+        initial="*",
+        validators=[month_of_year_validator],
+    )
+
+    class Meta:
+        model = ScheduledTask
+        fields = [
+            "name",
+            "description",
+            "status",
+            "function",
+            "parameters",
+            "environment",
+        ]
+
+    def __init__(self, *args, **kwargs):
+        env: Environment = kwargs.pop("env")
+        super().__init__(*args, **kwargs)
+        self.fields["function"].queryset = get_available_functions(env)
+        self.fields["status"].choices = self._get_status_choices()
+        self._setup_field_classes()
+
+    def clean(self):
+        cleaned_data = super().clean()
+        available_functions = get_available_functions(cleaned_data["environment"])
+        if cleaned_data["function"] not in available_functions:
+            self.add_error(
+                "function",
+                ValidationError("Unknown function was provided.", code="invalid"),
+            )
+
+        return cleaned_data
+
+    def _get_status_choices(self) -> list:
+        choices = []
+        for choice in ScheduledTask.STATUS_CHOICES:
+            if choice[0] == ScheduledTask.PENDING or choice[0] == ScheduledTask.ERROR:
+                continue
+            choices.append(choice)
+        return choices
+
+    def _setup_field_classes(self):
+        for field in self.fields:
+            self.fields[field].widget.attrs.update({"class": "input is-medium"})
+
+        self.fields["name"].widget.attrs.update(
+            {"class": "input is-medium is-fullwidth"}
+        )
+
+        self.fields["status"].widget.attrs.update(
+            {"class": "input is-medium is-fullwidth"}
+        )
+
+        self.fields["function"].widget.attrs.update(
+            {
+                "hx-get": reverse("ui:function-parameters"),
+                "hx-target": "#function-parameters",
+            }
+        )
+
+        self._setup_crontab_fields()
+
+    def _setup_crontab_fields(self):
+        """Ugly method to attach htmx properties to the crontab components"""
+
+        crontab_fields = [
+            "scheduled_minute",
+            "scheduled_hour",
+            "scheduled_day_of_week",
+            "scheduled_day_of_month",
+            "scheduled_month_of_year",
+        ]
+
+        for field in crontab_fields:
+            field_id = f"id_{field}"
+            field_url = field.replace("_", "-")
+            self.fields[field].widget.attrs.update(
+                {
+                    "hx-post": reverse(f"ui:{field_url}-param"),
+                    "hx-trigger": "keyup delay:500ms",
+                    "hx-target": f"#{field_id}_errors",
+                }
+            )

--- a/functionary/ui/templates/base.html
+++ b/functionary/ui/templates/base.html
@@ -35,6 +35,7 @@
         <script src="{% static 'js/pretty-print-json-1.2.min.js' %}"></script>
         <!-- This script will run when the page loads and the menus are available -->
         <script src="{% static 'js/highlight-menu-item.js' %}" defer></script>
+        <script src="{% static 'js/htmx-1.8.4.min.js' %}"></script>
         {% unicorn_scripts %}
     </head>
     <body>
@@ -103,6 +104,12 @@
                             <a href="{% url 'ui:function-list' %}">
                                 <span class="icon has-text-info"><i class="fa fa-lg fa-cube"></i></span>
                                 &nbsp;Functions
+                            </a>
+                        </li>
+                        <li class="menu-item">
+                            <a href="{% url 'ui:schedule-list' %}">
+                                <span class="icon has-text-info"><i class="fa fa-lg fa-clock"></i></span>
+                                &nbsp;Schedules
                             </a>
                         </li>
                     </ul>

--- a/functionary/ui/templates/core/scheduled_task_create.html
+++ b/functionary/ui/templates/core/scheduled_task_create.html
@@ -1,0 +1,219 @@
+{% extends "base.html" %}
+{% load static %}
+{% block content %}
+<div class="block">
+    {% if form %}
+        <form id="scheduled-task-create-form"
+                method="post"
+                action="{% url 'ui:create-schedule' %}">
+            {% csrf_token %}
+            
+            <!-- Non-Field Errors display -->
+            <div class="columns is-centered">
+                <div class="column has-text-centered is-half">
+                    {% if form.non_field_errors %}
+                    <div class="notification is-warning has-text-black">
+                        <button class="delete" onclick="return this.parentNode.remove();"></button>
+                        Non-Field Errors:
+                        {{ form.non_field_errors }}
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="box">
+
+                <!-- Name row/field -->
+                <div class="field">
+                    <div class="columns is-8">
+                        <div class="column is-one-third">
+                            <label for="{{ form.name.id_for_label }}">
+                                <b class="title is-size-4">{{ form.name.label }}</b> 
+                                <span class="is-small has-text-grey-light">{{ form.name.label_suffix }}</span>
+                                &nbsp;&nbsp;&nbsp;{{ form.name.help_text }}
+                            </label>
+                            <div class="column is-one-half p-0 is-italic subtitle is-size-6">
+                                <p>Give a descriptive name for your scheduled task.</p>
+                            </div>
+                            <div class="errorlist">
+                                {{ form.name.errors }}
+                            </div>
+                        </div>
+                        <div class="column">
+                            <div class="control">
+                                {{ form.name }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <hr/>
+
+                <!-- Description row/field -->
+                <div class="field">
+                    <div class="columns is-8">
+                        <div class="column is-one-third">
+                            <label for="{{ form.description.id_for_label }}">
+                                <b class="title is-size-4">{{ form.description.label }}</b> 
+                                <span class="is-small has-text-grey-light">{{ form.description.label_suffix }}</span>
+                                &nbsp;&nbsp;&nbsp;{{ form.description.help_text }}
+                            </label>
+                            <div class="column is-one-half p-0 is-italic subtitle is-size-6">
+                                <p>Give a description for your scheduled task.</p>
+                            </div>
+                            <div class="errorlist">
+                                {{ form.description.errors }}
+                            </div>
+                        </div>
+                        <div class="column">
+                            <div class="control">
+                                {{ form.description }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <hr/>
+
+                <!-- Function row/field -->
+                <div class="field">
+                    <div class="columns">
+                        <div class="column is-one-third">
+                            <label for="{{ form.function.id_for_label }}">
+                                <b class="title is-size-4">{{ form.function.label }}</b> 
+                                <span class="is-small has-text-grey-light">{{ form.function.label_suffix }}</span>
+                                &nbsp;&nbsp;&nbsp;{{ form.function.help_text }}
+                            </label>
+                            <div class="column p-0 is-italic subtitle is-size-6">
+                                <p>Select which function you want to schedule.</p>
+                            </div>
+                            <div class="errorlist">
+                                {{ form.function.errors }}
+                            </div>
+                        </div>
+                        <div class="column is-one-third">
+                            <div class="control">
+                                {{ form.function }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <hr/>
+
+                <!-- Crontab row/field -->
+                <div class="field">
+                    <div class="columns">
+                        <div class="column is-one-third">
+                            <label>
+                                <b class="title is-size-4">Crontab Schedule</b> 
+                            </label>
+                            <div class="column p-0 is-italic subtitle is-size-6">
+                                <p>Setup the Crontab-style schedule.</p>
+                            </div>
+                        </div>
+
+                        <div class="columns is-multiline">
+                            <div class="column is-one-third">
+                                <div class="box">
+                                    <label for="{{ form.scheduled_minute.id_for_label }}">
+                                        <span>{{ form.scheduled_minute.label}}</span>
+                                    </label>
+                                    <div class="control">
+                                        {{ form.scheduled_minute }}
+                                        {{ form.scheduled_minute.errors }}
+                                    </div>
+                                    <div id="{{ form.scheduled_minute.id_for_label }}_errors">
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="column is-one-third">
+                                <div class="box">
+                                    <label for="{{ form.scheduled_hour.id_for_label }}">
+                                        <span>{{ form.scheduled_hour.label}}</span>
+                                    </label>
+                                    <div class="control">
+                                        {{ form.scheduled_hour }}
+                                        {{ form.scheduled_hour.errors }}
+                                    </div>
+                                    <div id="{{ form.scheduled_hour.id_for_label }}_errors">
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="column is-one-third">
+                                <div class="box">
+                                    <label for="{{ form.scheduled_day_of_week.id_for_label }}">
+                                        <span>{{ form.scheduled_day_of_week.label}}</span>
+                                    </label>
+                                    <div class="control">
+                                        {{ form.scheduled_day_of_week }}
+                                        {{ form.scheduled_day_of_week.errors }}
+                                    </div>
+                                    <div id="{{ form.scheduled_day_of_week.id_for_label }}_errors">
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="column is-one-third">
+                                <div class="box">
+                                    <label for="{{ form.scheduled_day_of_month.id_for_label }}">
+                                        <span>{{ form.scheduled_day_of_month.label}}</span>
+                                    </label>
+                                    <div class="control">
+                                        {{ form.scheduled_day_of_month }}
+                                        {{ form.scheduled_day_of_month.errors }}
+                                    </div>
+                                    <div id="{{ form.scheduled_day_of_month.id_for_label }}_errors">
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="column is-one-third">
+                                <div class="box">
+                                    <label for="{{ form.scheduled_month_of_year.id_for_label }}">
+                                        <span>{{ form.scheduled_month_of_year.label}}</span>
+                                    </label>
+                                    <div class="control">
+                                        {{ form.scheduled_month_of_year }}
+                                        {{ form.scheduled_month_of_year.errors }}
+                                    </div>
+                                    <div id="{{ form.scheduled_month_of_year.id_for_label }}_errors">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <hr/>
+
+                <!-- Load function parameters -->
+                <div class="field">
+                    <div class="columns">
+                        <div class="column is-one-third">
+                            <label for="{{ form.parameters.id_for_label }}">
+                                <b class="title is-size-4">{{ form.parameters.label }}</b> 
+                                <span class="is-small has-text-grey-light">{{ form.parameters.label_suffix }}</span>
+                                &nbsp;&nbsp;&nbsp;{{ form.parameters.help_text }}
+                            </label>
+                            <div class="column p-0 is-italic subtitle is-size-6">
+                                Please enter the parameters for the function.
+                            </div>
+                            <div class="errorlist">
+                                {% if param_errors is not None %}
+                                    {{ param_errors }}
+                                {% endif %}
+                            </div>
+                        </div>
+                        <!-- Lazy load function parameters -->
+                        <div class="column" id="function-parameters" hx-trigger="load" hx-get="{% url 'ui:function-parameters' %}" hx-vals='{"function": "{{ function_id }}"}'>
+                        </div>
+                    </div>
+                </div>
+
+                <hr/>
+
+                <input class="button is-link" type="submit" value="Create"/>
+            </div>
+        </form>
+    {% endif %}
+</div>
+{% endblock content %}

--- a/functionary/ui/templates/core/scheduled_task_list.html
+++ b/functionary/ui/templates/core/scheduled_task_list.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+{% load static %}
+{% block content %}
+    <div>
+
+        <div class="columns is-centered">
+            <div class="column has-text-centered is-half">
+                {% if messages %}
+                {% for message in messages %}
+                <div class="notification is-warning">
+                    <button class="delete" onclick="return this.parentNode.remove();"></button>
+                    {{ message }}
+                </div>
+                {% endfor %}
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="level-right">
+
+            <a href="{% url 'ui:new-schedule' %}">
+                <button class="button level-item is-link m-5">
+                    <span class="icon is-small">
+                        <i class="fa fa-solid fa-plus"></i>
+                    </span>
+                    <span>
+                        Create New Scheduled Task
+                    </span>
+                </button>
+            </a>
+        </div>
+        <div class="table-container">
+            <table class="table is-hoverable is-fullwidth">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Function</th>
+                        <th>Last Run</th>
+                        <th>Schedule</th>
+                        <th>Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for scheduled_task in object_list %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'ui:schedule-detail' scheduled_task.id %}">{{ scheduled_task.name }}</a>
+                        </td>
+                        <td>
+                            {% if scheduled_task.function.display_name %}
+                                <a href="{% url 'ui:function-detail' scheduled_task.function.id%}">{{ scheduled_task.function.display_name }} ({{ scheduled_task.function.name }})</a>
+                            {% else %}
+                                <a href="{% url 'ui:function-detail' scheduled_task.function.id%}">{{ scheduled_task.function.name }}</a>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if scheduled_task.most_recent_task is None %}
+                                Not run yet
+                            {% else %}
+                                <a href="{% url 'ui:task-detail' scheduled_task.most_recent_task.id %}">{{ scheduled_task.most_recent_task.created_at }}</a>
+                            {% endif %}
+                        </td>
+                        <td>{{ scheduled_task.periodic_task.crontab }}</td>
+                        <td>{{ scheduled_task.status }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+{% endblock content %}

--- a/functionary/ui/templates/core/scheduled_task_update.html
+++ b/functionary/ui/templates/core/scheduled_task_update.html
@@ -1,0 +1,245 @@
+{% extends "base.html" %}
+{% load static %}
+{% block content %}
+<div class="block">
+    {% if form %}
+        <form id="scheduled-task-create-form"
+                method="post"
+                action="{% url 'ui:update-schedule' scheduledtask.id %}">
+            {% csrf_token %}
+            
+            <!-- Non-Field Errors display -->
+            <div class="columns is-centered">
+                <div class="column has-text-centered is-half">
+                    {% if form.non_field_errors %}
+                    <div class="notification is-warning has-text-black">
+                        <button class="delete" onclick="return this.parentNode.remove();"></button>
+                        Non-Field Errors:
+                        {{ form.non_field_errors }}
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+
+            <!-- Name row/field -->
+            <div class="box">
+
+                <div class="field">
+                    <div class="columns is-8">
+                        <div class="column is-one-third">
+                            <label for="{{ form.name.id_for_label }}">
+                                <b class="title is-size-4">{{ form.name.label }}</b> 
+                                <span class="is-small has-text-grey-light">{{ form.name.label_suffix }}</span>
+                                &nbsp;&nbsp;&nbsp;{{ form.name.help_text }}
+                            </label>
+                            <div class="column is-one-half p-0 is-italic subtitle is-size-6">
+                                <p>Give a descriptive name for your scheduled task.</p>
+                            </div>
+                            <div class="errorlist">
+                                {{ form.name.errors }}
+                            </div>
+                        </div>
+                        <div class="column">
+                            <div class="control">
+                                {{ form.name }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <hr/>
+
+                <!-- Status row/field -->
+                <div class="field">
+                    <div class="columns is-8">
+                        <div class="column is-one-third">
+                            <label for="{{ form.status.id_for_label }}">
+                                <b class="title is-size-4">{{ form.status.label }}</b> 
+                                <span class="is-small has-text-grey-light">{{ form.status.label_suffix }}</span>
+                                &nbsp;&nbsp;&nbsp;{{ form.status.help_text }}
+                            </label>
+                            <div class="column is-one-half p-0 is-italic subtitle is-size-6">
+                                <p>Update the status of your scheduled task.</p>
+                            </div>
+                            <div class="errorlist">
+                                {{ form.status.errors }}
+                            </div>
+                        </div>
+                        <div class="column is-one-third">
+                            <div class="control">
+                                {{ form.status }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <hr/>
+
+                <!-- Description row/field -->
+                <div class="field">
+                    <div class="columns is-8">
+                        <div class="column is-one-third">
+                            <label for="{{ form.description.id_for_label }}">
+                                <b {% if form.description.errors %}class="errors"{% endif %} class="title is-size-4">{{ form.description.label }}</b> 
+                                <span class="is-small has-text-grey-light">{{ form.description.label_suffix }}</span>
+                                &nbsp;&nbsp;&nbsp;{{ form.description.help_text }}
+                            </label>
+                            <div class="column is-one-half p-0 is-italic subtitle is-size-6">
+                                <p>Give a description for your scheduled task.</p>
+                            </div>
+                            <div class="errorlist">
+                                {{ form.description.errors }}
+                            </div>
+                        </div>
+                        <div class="column">
+                            <div class="control">
+                                {{ form.description }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <hr/>
+
+                <!-- Function row/field -->
+                <div class="field">
+                    <div class="columns">
+                        <div class="column is-one-third">
+                            <label for="{{ form.function.id_for_label }}">
+                                <b class="title is-size-4">{{ form.function.label }}</b> 
+                                <span class="is-small has-text-grey-light">{{ form.function.label_suffix }}</span>
+                                &nbsp;&nbsp;&nbsp;{{ form.function.help_text }}
+                            </label>
+                            <div class="column p-0 is-italic subtitle is-size-6">
+                                <p>Select which function you want to schedule.</p>
+                            </div>
+                            <div class="errorlist">
+                                {{ form.function.errors }}
+                            </div>
+                        </div>
+                        <div class="column is-one-third">
+                            <div class="control">
+                                {{ form.function }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <hr/>
+
+                <!-- Crontab row/field -->
+                <div class="field">
+                    <div class="columns">
+                        <div class="column is-one-third">
+                            <label>
+                                <b class="title is-size-4">Crontab Schedule</b> 
+                            </label>
+                            <div class="column p-0 is-italic subtitle is-size-6">
+                                <p>Setup the Crontab-style schedule.</p>
+                            </div>
+                        </div>
+
+                        <div class="columns is-multiline">
+                            <div class="column is-one-third">
+                                <div class="box">
+                                    <label for="{{ form.scheduled_minute.id_for_label }}">
+                                        <span>{{ form.scheduled_minute.label}}</span>
+                                    </label>
+                                    <div class="control">
+                                        {{ form.scheduled_minute }}
+                                        {{ form.scheduled_minute.errors }}
+                                    </div>
+                                    <div id="{{ form.scheduled_minute.id_for_label }}_errors">
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="column is-one-third">
+                                <div class="box">
+                                    <label for="{{ form.scheduled_hour.id_for_label }}">
+                                        <span>{{ form.scheduled_hour.label}}</span>
+                                    </label>
+                                    <div class="control">
+                                        {{ form.scheduled_hour }}
+                                        {{ form.scheduled_hour.errors }}
+                                    </div>
+                                    <div id="{{ form.scheduled_hour.id_for_label }}_errors">
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="column is-one-third">
+                                <div class="box">
+                                    <label for="{{ form.scheduled_day_of_week.id_for_label }}">
+                                        <span>{{ form.scheduled_day_of_week.label}}</span>
+                                    </label>
+                                    <div class="control">
+                                        {{ form.scheduled_day_of_week }}
+                                        {{ form.scheduled_day_of_week.errors }}
+                                    </div>
+                                    <div id="{{ form.scheduled_day_of_week.id_for_label }}_errors">
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="column is-one-third">
+                                <div class="box">
+                                    <label for="{{ form.scheduled_day_of_month.id_for_label }}">
+                                        <span>{{ form.scheduled_day_of_month.label}}</span>
+                                    </label>
+                                    <div class="control">
+                                        {{ form.scheduled_day_of_month }}
+                                        {{ form.scheduled_day_of_month.errors }}
+                                    </div>
+                                    <div id="{{ form.scheduled_day_of_month.id_for_label }}_errors">
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="column is-one-third">
+                                <div class="box">
+                                    <label for="{{ form.scheduled_month_of_year.id_for_label }}">
+                                        <span>{{ form.scheduled_month_of_year.label}}</span>
+                                    </label>
+                                    <div class="control">
+                                        {{ form.scheduled_month_of_year }}
+                                        {{ form.scheduled_month_of_year.errors }}
+                                    </div>
+                                    <div id="{{ form.scheduled_month_of_year.id_for_label }}_errors">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <hr/>
+
+                <!-- Load function parameters -->
+                <div class="field">
+                    <div class="columns">
+                        <div class="column is-one-third">
+                            <label for="{{ form.parameters.id_for_label }}">
+                                <b class="title is-size-4">{{ form.parameters.label }}</b> 
+                                <span class="is-small has-text-grey-light">{{ form.parameters.label_suffix }}</span>
+                                &nbsp;&nbsp;&nbsp;{{ form.parameters.help_text }}
+                            </label>
+                            <div class="column p-0 is-italic subtitle is-size-6">
+                                Please enter the parameters for the function.
+                            </div>
+                            <div class="errorlist">
+                                {% if param_errors is not None %}
+                                    {{ param_errors }}
+                                {% endif %}
+                            </div>
+                        </div>
+                        <!-- Lazy load function parameters -->
+                        <div class="column" id="function-parameters" hx-trigger="load" hx-get="{% url 'ui:function-parameters' %}" hx-vals='{"function": "{{ function_id }}", "scheduled_task_id": "{{ scheduled_task_id }}"}'>
+                        </div>
+                    </div>
+                </div>
+
+                <hr/>
+
+                <input class="button is-link" type="submit" value="Update"/>
+            </div>
+        </form>
+    {% endif %}
+</div>
+{% endblock content %}

--- a/functionary/ui/templates/partials/crontab_invalid.html
+++ b/functionary/ui/templates/partials/crontab_invalid.html
@@ -1,0 +1,3 @@
+<div class="help is-danger">
+    {{ field }} is invalid.
+</div>

--- a/functionary/ui/templates/partials/function_parameters.html
+++ b/functionary/ui/templates/partials/function_parameters.html
@@ -1,0 +1,6 @@
+{% for parameter in parameters %}
+    <div class="control pb-2">
+        <label for="{{ parameter.label }}"><b>{{ parameter.label }}: </b><i>{{ parameter.label_suffix }}</i></label>
+        {{ parameter.widget }}    
+    </div>
+{% endfor %}

--- a/functionary/ui/urls.py
+++ b/functionary/ui/urls.py
@@ -8,6 +8,7 @@ from .views import (
     functions,
     home,
     packages,
+    scheduling,
     tasks,
     teams,
     variables,
@@ -17,6 +18,11 @@ app_name = "ui"
 
 urlpatterns = [
     path("", home.home, name="home"),
+    path(
+        "create_schedule/",
+        (scheduling.create_scheduled_task),
+        name="create-schedule",
+    ),
     path(
         "build_list/",
         (builds.BuildListView.as_view()),
@@ -49,6 +55,11 @@ urlpatterns = [
     ),
     path("function_execute/", (functions.execute), name="function-execute"),
     path(
+        "new_schedule/",
+        (scheduling.ScheduledTaskCreateView.as_view()),
+        name="new-schedule",
+    ),
+    path(
         "package_list/",
         (packages.PackageListView.as_view()),
         name="package-list",
@@ -57,6 +68,16 @@ urlpatterns = [
         "package/<uuid:pk>",
         (packages.PackageDetailView.as_view()),
         name="package-detail",
+    ),
+    path(
+        "schedule/<uuid:pk>",
+        (scheduling.ScheduledTaskUpdateView.as_view()),
+        name="schedule-detail",
+    ),
+    path(
+        "schedule_list/",
+        (scheduling.ScheduledTaskListView.as_view()),
+        name="schedule-list",
     ),
     path("task_list/", (tasks.TaskListView.as_view()), name="task-list"),
     path(
@@ -69,6 +90,11 @@ urlpatterns = [
         "team/<uuid:pk>",
         (teams.TeamDetailView.as_view()),
         name="team-detail",
+    ),
+    path(
+        "update_schedule/<uuid:pk>",
+        (scheduling.update_scheduled_task),
+        name="update-schedule",
     ),
     path(
         "environment/set_environment_id",
@@ -102,3 +128,39 @@ urlpatterns = [
     ),
     path("", include("django.contrib.auth.urls")),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+
+
+htmx_urlpatterns = [
+    path(
+        "crontab_minute_param/",
+        (scheduling.crontab_minute_param),
+        name="scheduled-minute-param",
+    ),
+    path(
+        "crontab_hour_param/",
+        (scheduling.crontab_hour_param),
+        name="scheduled-hour-param",
+    ),
+    path(
+        "crontab_day_of_week_param/",
+        (scheduling.crontab_day_of_week_param),
+        name="scheduled-day-of-week-param",
+    ),
+    path(
+        "crontab_day_of_month_param/",
+        (scheduling.crontab_day_of_month_param),
+        name="scheduled-day-of-month-param",
+    ),
+    path(
+        "crontab_month_of_year_param/",
+        (scheduling.crontab_month_of_year_param),
+        name="scheduled-month-of-year-param",
+    ),
+    path(
+        "function_parameters/",
+        (scheduling.function_parameters),
+        name="function-parameters",
+    ),
+]
+
+urlpatterns += htmx_urlpatterns

--- a/functionary/ui/views/scheduling.py
+++ b/functionary/ui/views/scheduling.py
@@ -1,0 +1,285 @@
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.http import (
+    HttpRequest,
+    HttpResponse,
+    HttpResponseForbidden,
+    HttpResponseNotFound,
+    HttpResponseRedirect,
+    QueryDict,
+)
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
+from django.views.decorators.http import require_GET, require_POST
+
+from core.auth import Permission
+from core.models import Environment, ScheduledTask
+from core.utils.scheduling import (
+    create_periodic_task,
+    get_function,
+    get_parameters,
+    is_valid_scheduled_day_of_month,
+    is_valid_scheduled_day_of_week,
+    is_valid_scheduled_hour,
+    is_valid_scheduled_minute,
+    is_valid_scheduled_month_of_year,
+    update_crontab,
+    update_status,
+)
+
+from ..forms.tasks import ScheduledTaskForm, TaskParameterForm, get_available_functions
+from .view_base import (
+    PermissionedEnvironmentListView,
+    PermissionedFormCreateView,
+    PermissionedFormUpdateView,
+)
+
+
+class ScheduledTaskListView(PermissionedEnvironmentListView):
+    model = ScheduledTask
+    template_name = "core/scheduled_task_list.html"
+
+
+class ScheduledTaskCreateView(PermissionedFormCreateView):
+    model = ScheduledTask
+    form_class = ScheduledTaskForm
+    success_url = "/schedule_list"
+    template_name = "core/scheduled_task_create.html"
+
+    def get(self, *args, **kwargs):
+        env = Environment.objects.get(id=self.request.session.get("environment_id"))
+        if not len(get_available_functions(env)):
+            messages.warning(
+                self.request,
+                "No available functions to schedule in current environment.",
+            )
+            return redirect("ui:schedule-list")
+        return super().get(*args, **kwargs)
+
+    def get_form_kwargs(self) -> dict:
+        kwargs = super().get_form_kwargs()
+        kwargs["env"] = Environment.objects.get(
+            id=self.request.session.get("environment_id")
+        )
+        return kwargs
+
+
+class ScheduledTaskUpdateView(PermissionedFormUpdateView):
+    model = ScheduledTask
+    form_class = ScheduledTaskForm
+    success_url = "/schedule_list"
+    template_name = "core/scheduled_task_update.html"
+
+    def get_form_kwargs(self) -> dict:
+        """Add session environment to form kwargs to initialize available functions"""
+        kwargs = super().get_form_kwargs()
+        kwargs["env"] = Environment.objects.get(
+            id=self.request.session.get("environment_id")
+        )
+        return kwargs
+
+    def get_initial(self):
+        """Use existing ScheduledTask to fill in existing values in the form"""
+        initial = super().get_initial()
+        scheduled_task: ScheduledTask = self.get_object()
+        crontab = scheduled_task.periodic_task.crontab
+        initial["scheduled_minute"] = crontab.minute
+        initial["scheduled_hour"] = crontab.hour
+        initial["scheduled_day_of_week"] = crontab.day_of_week
+        initial["scheduled_day_of_month"] = crontab.day_of_month
+        initial["scheduled_month_of_year"] = crontab.month_of_year
+        return initial
+
+    def get_context_data(self, **kwargs) -> dict:
+        """Add function_id and scheduled_task_id to context
+
+        This is used for lazy loading the function parameters.
+        """
+        context = super().get_context_data(**kwargs)
+        scheduled_task: ScheduledTask = self.get_object()
+        context["function_id"] = str(scheduled_task.function.id)
+        context["scheduled_task_id"] = str(scheduled_task.id)
+        return context
+
+
+@require_POST
+@login_required
+def create_scheduled_task(request: HttpRequest) -> HttpResponse:
+    """Handles form submission for creating a new scheduled task"""
+    env = Environment.objects.get(id=request.session.get("environment_id"))
+    if not request.user.has_perm(Permission.TASK_CREATE, env):
+        return HttpResponseForbidden()
+
+    func = get_function(request.POST.get("function"), env)
+    if isinstance(func, HttpResponseNotFound):
+        return func
+
+    data: QueryDict = request.POST.copy()
+    data["function"] = func
+    data["environment"] = env
+    data["status"] = ScheduledTask.PAUSED
+    function_params_form = TaskParameterForm(func, data)
+
+    # Validate function parameters
+    param_errors = None
+    if function_params_form.is_valid():
+        data["parameters"] = function_params_form.cleaned_data
+    else:
+        param_errors = function_params_form.errors
+
+    form = ScheduledTaskForm(data=data, env=env)
+    if form.is_valid():
+        _create_scheduled_task(
+            request, form.cleaned_data, function_params_form.cleaned_data
+        )
+        return HttpResponseRedirect(reverse("ui:schedule-list"))
+
+    context = {
+        "form": ScheduledTaskForm(data=data, env=env),
+        "errors": form.errors,
+        "param_errors": param_errors,
+        "function_id": str(func.id),
+    }
+    return render(request, "core/scheduled_task_create.html", context)
+
+
+@require_POST
+@login_required
+def update_scheduled_task(request: HttpRequest, pk: str) -> HttpResponse:
+    env = Environment.objects.get(id=request.session.get("environment_id"))
+    if not request.user.has_perm(Permission.TASK_CREATE, env):
+        return HttpResponseForbidden()
+
+    scheduled_task = get_object_or_404(ScheduledTask, id=pk)
+    func = get_function(request.POST.get("function"), env)
+    if isinstance(func, HttpResponseNotFound):
+        return func
+
+    data: QueryDict = request.POST.copy()
+    data["function"] = func
+    data["environment"] = env
+    function_params_form = TaskParameterForm(func, data)
+
+    # Validate function parameters
+    param_errors = None
+    if function_params_form.is_valid():
+        data["parameters"] = function_params_form.cleaned_data
+    else:
+        param_errors = function_params_form.errors
+
+    form = ScheduledTaskForm(data=data, env=env, instance=scheduled_task)
+    if form.is_valid():
+        form.save()
+        update_status(form.cleaned_data["status"], scheduled_task)
+        update_crontab(form.cleaned_data, scheduled_task)
+        return HttpResponseRedirect(reverse("ui:schedule-list"))
+
+    """
+    Return the string representation of the function and scheduled task ids
+    so that the parameters can be lazy loaded via htmx.
+    """
+    context = {
+        "form": ScheduledTaskForm(data=data, env=env),
+        "errors": form.errors,
+        "param_errors": param_errors,
+        "scheduledtask": scheduled_task,
+        "function_id": str(func.id),
+        "scheduled_task_id": str(scheduled_task.id),
+    }
+    return render(request, "core/scheduled_task_update.html", context)
+
+
+@require_GET
+@login_required
+def function_parameters(request: HttpRequest) -> HttpResponse:
+    """Used to lazy load a function's parameters as a partial.
+
+    Always expects a 'function_id' parameter in the request, which is the ID of the
+    function object whose parameters should be rendered.
+    """
+    env = Environment.objects.get(id=request.session.get("environment_id"))
+    if not request.user.has_perm(Permission.TASK_CREATE, env):
+        return HttpResponseForbidden()
+
+    if (function_id := request.GET.get("function", None)) in ["", None]:
+        return HttpResponse("No function selected.")
+
+    func = get_function(function_id, env)
+    if isinstance(func, HttpResponseNotFound):
+        return func
+
+    """
+    If the request includes the scheduled_task_id, substitute the default
+    widget values for the existing ScheduledTask parameters.
+    """
+    existing_parameters = None
+    if (scheduled_task_id := request.GET.get("scheduled_task_id", None)) is not None:
+        scheduled_task = ScheduledTask.objects.get(id=scheduled_task_id)
+        existing_parameters = scheduled_task.parameters
+
+    parameters = get_parameters(func, parameter_values=existing_parameters)
+    context = {"parameters": parameters}
+    return render(request, "partials/function_parameters.html", context)
+
+
+@require_POST
+@login_required
+def crontab_minute_param(request: HttpRequest) -> HttpResponse:
+    if not is_valid_scheduled_minute(request.POST.get("scheduled_minute")):
+        return render(request, "partials/crontab_invalid.html", {"field": "Minute"})
+    return HttpResponse("")
+
+
+@require_POST
+@login_required
+def crontab_hour_param(request: HttpRequest) -> HttpResponse:
+    if not is_valid_scheduled_hour(request.POST.get("scheduled_hour")):
+        return render(request, "partials/crontab_invalid.html", {"field": "Hour"})
+    return HttpResponse("")
+
+
+@require_POST
+@login_required
+def crontab_day_of_week_param(request: HttpRequest) -> HttpResponse:
+    if not is_valid_scheduled_day_of_week(request.POST.get("scheduled_day_of_week")):
+        return render(
+            request, "partials/crontab_invalid.html", {"field": "Day of week"}
+        )
+    return HttpResponse("")
+
+
+@require_POST
+@login_required
+def crontab_day_of_month_param(request: HttpRequest) -> HttpResponse:
+    if not is_valid_scheduled_day_of_month(request.POST.get("scheduled_day_of_month")):
+        return render(
+            request, "partials/crontab_invalid.html", {"field": "Day of month"}
+        )
+    return HttpResponse("")
+
+
+@require_POST
+@login_required
+def crontab_month_of_year_param(request: HttpRequest) -> HttpResponse:
+    if not is_valid_scheduled_month_of_year(
+        request.POST.get("scheduled_month_of_year")
+    ):
+        return render(
+            request, "partials/crontab_invalid.html", {"field": "Month of year"}
+        )
+    return HttpResponse("")
+
+
+def _create_scheduled_task(request: HttpRequest, data: dict, task_params: dict):
+    """Helper function for creating scheduled task"""
+    scheduled_task = ScheduledTask.objects.create(
+        name=data["name"],
+        environment=data["environment"],
+        description=data["description"],
+        function=data["function"],
+        parameters=task_params,
+        creator=request.user,
+    )
+
+    _ = create_periodic_task(data, scheduled_task)
+    scheduled_task.activate()

--- a/functionary/ui/views/view_base.py
+++ b/functionary/ui/views/view_base.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.views.generic import CreateView, UpdateView
 from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 
@@ -47,4 +48,16 @@ class PermissionedEnvironmentDetailView(
         else:
             env = self.get_object().environment
 
+        return self.request.user.has_perm(Permission.ENVIRONMENT_READ, env)
+
+
+class PermissionedFormCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
+    def test_func(self):
+        env = self.request.session.get("environment_id")
+        return self.request.user.has_perm(Permission.ENVIRONMENT_READ, env)
+
+
+class PermissionedFormUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
+    def test_func(self):
+        env = self.request.session.get("environment_id")
         return self.request.user.has_perm(Permission.ENVIRONMENT_READ, env)


### PR DESCRIPTION
Closes #114 

## Introduced Changes
- Added scheduled task list, create, and update pages
- Dynamically load function parameters with htmx
- Dynamically validate crontab fields with htmx
- Added separate htmx urls
- Display message to user if they have no scheduled tasks they can make in their current environment
- Display form errors when creating or updating a `ScheduledTask`


## Testing
- Launch Functionary and view the `Scheduling` UI
- Create tasks and verify they run according to the crontab schedule
- Update tasks to verify their next run reflects those updates
- Try and submit invalid data to the forms and verify you receive an error


## Notes
- There are some helper functions in `core.utils.scheduling` that I think can be migrated over to the `ScheduledTask` model
- With my current implementation, I do not persist parameter arguments when a form gets rejected. The parameter values will reset to their defaults according to their widget type