### PR TITLE
#141 - Added pagination to TaskList, added ability to get task logs

### DIFF
--- a/functionary/ui/templates/core/task_detail.html
+++ b/functionary/ui/templates/core/task_detail.html
@@ -1,8 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
     <div id="task_detail"
-         hx-swap-oob="true"
-         {% if not completed %} hx-get="{% url 'ui:task-results' task.id %}?output=display_raw&poll=true" hx-target="#result" hx-trigger="every 5s"{% endif %}>
+         {% if not completed %} hx-get="{% url 'ui:task-results' task.id %}?output=display_raw&poll=true" hx-trigger="every 5s"{% endif %}>
         <div class="block">
             <nav class="breadcrumb has-arrow-separator" aria-label="breadcrumbs">
                 <ul>
@@ -49,7 +48,7 @@
                 <label class="label" for="result">
                     <i class="fa fa-clipboard-check"></i>&nbsp;Result:
                 </label>
-                {% include "partials/task_result.html" %}
+                {% include 'partials/task_result_block.html' %}
             </div>
         </div>
     </div>

--- a/functionary/ui/templates/core/task_list.html
+++ b/functionary/ui/templates/core/task_list.html
@@ -1,33 +1,11 @@
 {% extends "base.html" %}
+{% load static %}
 {% block content %}
-    <div>
-        {% for task in object_list %}
-            <div class="block">
-                <div class="card">
-                    <div class="card-content">
-                        <div class="media">
-                            <div class="media-left">
-                                <span class="icon is-large">
-                                    <i class="fa fa-2x fa-digital-tachograph"></i>
-                                </span>
-                            </div>
-                            <div class="media-content">
-                                <a href="{% url 'ui:task-detail' task.id %}">
-                                    <p class="title is-4">
-                                        {{ task.function.name }}
-                                        &nbsp;&nbsp;
-                                    </p>
-                                </a>
-                                <p class="subtitle is-6">
-                                    <span><i class="fa fa-user"></i>&nbsp;{{ task.creator.username }}</span>
-                                    <br/>
-                                    <span class="is-size-6 has-text-weight-normal">(Created at {{ task.created_at }})</span>
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        {% endfor %}
+{% for task in page_obj %}
+    <div class="mb-2">
+        {% include 'partials/task_element.html' with task=task %}
     </div>
-{% endblock content %}
+{% endfor %}
+
+{% include 'partials/pagination_navbar.html' with page_obj=page_obj paginator=paginator %}
+{% endblock %}

--- a/functionary/ui/templates/partials/output.html
+++ b/functionary/ui/templates/partials/output.html
@@ -1,0 +1,7 @@
+{% if output_format == "json" %}
+    {% include "partials/output_json.html" %}
+{% elif output_format == "table" %}
+    {% include "partials/output_table.html" %}
+{% else %}
+    {% include "partials/output_string.html" %}
+{% endif %}

--- a/functionary/ui/templates/partials/pagination_navbar.html
+++ b/functionary/ui/templates/partials/pagination_navbar.html
@@ -1,0 +1,35 @@
+{% load paginator %}
+<div class="container mt-4">
+    <div class="columns">
+        <div class="column has-text-centered">
+            <nav class="pagination is-centered" role="navigation">
+                {% if page_obj.has_previous %}
+                    <a class="pagination-previous" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+                {% else %}
+                    <a class="pagination-previous is-disabled">Previous</a>
+                {% endif %}
+        
+                {% if page_obj.has_next %}
+                    <a class="pagination-next" href="?page={{ page_obj.next_page_number }}">Next page</a>
+                {% else %}
+                    <a class="pagination-next is-disabled">Next page</a>
+                {% endif %}
+        
+                <ul class="pagination-list">
+                    {% get_updated_elided_page_range paginator page_obj.number as page_range %}
+                    {% for page_number in page_range %}
+                        {% if page_number == page_obj.number %}
+                            <li><a class="pagination-link is-current" href="?page={{ page_number }}">{{ page_number }}</a></li>
+                        {% else %}
+                            {% if page_number == page_obj.paginator.ELLIPSIS %}
+                                <li><a class="pagination-link">{{ page_number }}</a></li>
+                            {% else %}
+                                <li><a class="pagination-link" href="?page={{ page_number }}">{{ page_number }}</a></li>
+                            {% endif %}
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </nav>
+        </div>
+    </div>
+</div>

--- a/functionary/ui/templates/partials/task_element.html
+++ b/functionary/ui/templates/partials/task_element.html
@@ -1,0 +1,28 @@
+<a href="{% url 'ui:task-detail' task.id %}">
+    <div class="block">
+        <div class="card">
+            <div class="card-content">
+                <div class="media">
+                    <div class="media-left">
+                        <span class="icon is-large">
+                            <i class="fa fa-2x fa-digital-tachograph"></i>
+                        </span>
+                    </div>
+                    <div class="media-content">
+                    
+                        <p class="title is-4">
+                            {{ task.function.name }}
+                            &nbsp;&nbsp;
+                        </p>
+                    
+                        <p class="subtitle is-6">
+                            <span><i class="fa fa-user"></i>&nbsp;{{ task.creator.username }}</span>
+                            <br/>
+                            <span class="is-size-6 has-text-weight-normal">(Created at {{ task.created_at }})</span>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</a>

--- a/functionary/ui/templates/partials/task_log.html
+++ b/functionary/ui/templates/partials/task_log.html
@@ -1,0 +1,7 @@
+<div>
+    {% if task_log == "" %}
+        <p>This task does not have any logs to display.</p>
+    {% else %}
+        <pre class="mr-4">{{ task_log }}</pre>
+    {% endif %}
+</div>

--- a/functionary/ui/templates/partials/task_log.html
+++ b/functionary/ui/templates/partials/task_log.html
@@ -1,7 +1,7 @@
 <div>
-    {% if task_log == "" %}
+    {% if task.log == "" %}
         <p>This task does not have any logs to display.</p>
     {% else %}
-        <pre class="mr-4">{{ task_log }}</pre>
+        <pre class="mr-4">{{ task.log }}</pre>
     {% endif %}
 </div>

--- a/functionary/ui/templates/partials/task_result.html
+++ b/functionary/ui/templates/partials/task_result.html
@@ -1,25 +1,7 @@
-<div id="result" class="block ml-4 is-12" hx-swap-oob="true">
-    {% if show_output_selector %}
-        <div class="tabs is-small is-toggle ml-4">
-            <ul hx-target="#result">
-                <li {% if output_format != "table" %}class="is-active"{% endif %}>
-                    <a hx-get="{% url 'ui:task-results' task.id %}?output=display_raw">Raw</a>
-                </li>
-                <li {% if output_format == "table" %}class="is-active"{% endif %}>
-                    <a hx-get="{% url 'ui:task-results' task.id %}?output=display_table">Table</a>
-                </li>
-            </ul>
-        </div>
-    {% endif %}
-    {% if not completed %}
-        <i id="result_indicator" class="fas fa-spinner fa-spin fa-2x"></i>
-    {% elif task.result is None %}
-        {% include "partials/output_none.html" %}
-    {% elif output_format == "json" %}
-        {% include "partials/output_json.html" %}
-    {% elif output_format == "table" %}
-        {% include "partials/output_table.html" %}
-    {% else %}
-        {% include "partials/output_string.html" %}
-    {% endif %}
-</div>
+{% if output_format == "log" %}
+    {% include "partials/task_log.html" %}
+{% elif task.result is None %}
+    {% include "partials/output_none.html" %}
+{% else %}
+    {% include "partials/output.html" with output_format=output_format %}
+{% endif %}

--- a/functionary/ui/templates/partials/task_result_block.html
+++ b/functionary/ui/templates/partials/task_result_block.html
@@ -6,17 +6,16 @@
                     <a hx-get="{% url 'ui:task-results' task.id %}?output=display_raw">Raw</a>
                 </li>
                 {% if show_output_selector %}
-                <li {% if output_format == "table" %}class="is-active"{% endif %}>
-                    <a hx-get="{% url 'ui:task-results' task.id %}?output=display_table">Table</a>
-                </li>
+                    <li {% if output_format == "table" %}class="is-active"{% endif %}>
+                        <a hx-get="{% url 'ui:task-results' task.id %}?output=display_table">Table</a>
+                    </li>
                 {% endif %}
-                <li {% if output_format == "log" %}class="is-active"{% endif %}> 
+                <li {% if output_format == "log" %}class="is-active"{% endif %}>
                     <a hx-get="{% url 'ui:task-log' pk=task.id %}">Log</a>
                 </li>
             </ul>
         </div>
-
-        {% include 'partials/task_result.html' %}
+        {% include "partials/task_result.html" %}
     </div>
 {% else %}
     <i id="result_indicator" class="fas fa-spinner fa-spin fa-2x ml-4"></i>

--- a/functionary/ui/templates/partials/task_result_block.html
+++ b/functionary/ui/templates/partials/task_result_block.html
@@ -1,0 +1,23 @@
+{% if completed %}
+    <div id="result-block" class="block ml-4 is-12" hx-swap-oob="true">
+        <div class="tabs is-small is-toggle">
+            <ul hx-target="#result-block">
+                <li {% if output_format != "table" and output_format != "log" %}class="is-active"{% endif %}>
+                    <a hx-get="{% url 'ui:task-results' task.id %}?output=display_raw">Raw</a>
+                </li>
+                {% if show_output_selector %}
+                <li {% if output_format == "table" %}class="is-active"{% endif %}>
+                    <a hx-get="{% url 'ui:task-results' task.id %}?output=display_table">Table</a>
+                </li>
+                {% endif %}
+                <li {% if output_format == "log" %}class="is-active"{% endif %}> 
+                    <a hx-get="{% url 'ui:task-log' pk=task.id %}">Log</a>
+                </li>
+            </ul>
+        </div>
+
+        {% include 'partials/task_result.html' %}
+    </div>
+{% else %}
+    <i id="result_indicator" class="fas fa-spinner fa-spin fa-2x ml-4"></i>
+{% endif %}

--- a/functionary/ui/templatetags/paginator.py
+++ b/functionary/ui/templatetags/paginator.py
@@ -1,0 +1,32 @@
+from collections.abc import Iterable
+
+from django import template
+from django.core.paginator import Paginator
+
+register = template.Library()
+
+
+@register.simple_tag
+def get_updated_elided_page_range(
+    paginator: Paginator, number: int, on_each_side: int = 3, on_ends: int = 2
+) -> Iterable:
+    """Get an updated list of elided pages based on the passed in page number
+
+    Gets a new list of pages, including the ellipsis, in the pagination navbar whenever
+    the user goes to a new page.
+
+    Args:
+        paginator: The Paginator for the paginated view
+        number: An integer of the current page number
+        on_each_side: An integer for how many pages should be displayed
+            on both sides of the current page
+        on_ends: An integer for how many pages should be displayed
+            on the end of the page list, past the ellipsis
+
+    Returns:
+        new_paginator: An iterable of the new list of elided pages
+    """
+    new_paginator = Paginator(paginator.object_list, paginator.per_page)
+    return new_paginator.get_elided_page_range(
+        number=number, on_each_side=on_each_side, on_ends=on_ends
+    )

--- a/functionary/ui/urls.py
+++ b/functionary/ui/urls.py
@@ -85,6 +85,7 @@ urlpatterns = [
         (tasks.TaskDetailView.as_view()),
         name="task-detail",
     ),
+    path("task/<pk>/log", (tasks.get_task_log), name="task-log"),
     path(
         "task/<uuid:pk>/results",
         (tasks.TaskResultsView.as_view()),

--- a/functionary/ui/views/tasks.py
+++ b/functionary/ui/views/tasks.py
@@ -1,10 +1,19 @@
 import csv
 
-from django.core.exceptions import BadRequest
-from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import BadRequest, ValidationError
+from django.http import (
+    HttpRequest,
+    HttpResponse,
+    HttpResponseForbidden,
+    HttpResponseNotFound,
+)
+from django.shortcuts import get_object_or_404, render
+from django.views.decorators.http import require_GET
 from django_htmx import http
 
-from core.models import Task
+from core.auth import Permission
+from core.models import Environment, Task, TaskLog
 
 from .view_base import (
     PermissionedEnvironmentDetailView,
@@ -12,6 +21,7 @@ from .view_base import (
 )
 
 FINISHED_STATUS = ["COMPLETE", "ERROR"]
+PAGINATION_AMOUNT = 8
 
 
 def _detect_csv(result):
@@ -132,6 +142,7 @@ class TaskListView(PermissionedEnvironmentListView):
     model = Task
     order_by_fields = ["-created_at"]
     queryset = Task.objects.select_related("environment", "function", "creator").all()
+    paginate_by = PAGINATION_AMOUNT
 
 
 class TaskDetailView(PermissionedEnvironmentDetailView):
@@ -187,4 +198,34 @@ class TaskResultsView(PermissionedEnvironmentDetailView):
                 "#task_detail",
             )
 
-        return render(request, "partials/task_result.html", context=context)
+        return render(request, "partials/task_result_block.html", context=context)
+
+
+@require_GET
+@login_required
+def get_task_log(request: HttpRequest, pk: str) -> HttpResponse:
+    env = Environment.objects.get(id=request.session.get("environment_id"))
+    if not request.user.has_perm(Permission.TASK_READ, env):
+        return HttpResponseForbidden()
+
+    task = None
+    try:
+        # Use try/except in case of invalid task_id uuid format
+        task = get_object_or_404(Task, id=pk, environment=env)
+    except ValidationError:
+        return HttpResponseNotFound("Unknown task submitted.")
+
+    completed = task.status in FINISHED_STATUS
+    task_log = TaskLog.objects.get(task=task)
+    show_output_selector = (
+        False if not completed else _show_output_selector(task.result)
+    )
+
+    context = {
+        "task": task,
+        "completed": completed,
+        "show_output_selector": show_output_selector,
+        "task_log": task_log.log,
+        "output_format": "log",
+    }
+    return render(request, "partials/task_result_block.html", context)

--- a/functionary/ui/views/tasks.py
+++ b/functionary/ui/views/tasks.py
@@ -13,7 +13,7 @@ from django.views.decorators.http import require_GET
 from django_htmx import http
 
 from core.auth import Permission
-from core.models import Environment, Task, TaskLog
+from core.models import Environment, Task
 
 from .view_base import (
     PermissionedEnvironmentDetailView,
@@ -208,7 +208,6 @@ def get_task_log(request: HttpRequest, pk: str) -> HttpResponse:
     if not request.user.has_perm(Permission.TASK_READ, env):
         return HttpResponseForbidden()
 
-    task = None
     try:
         # Use try/except in case of invalid task_id uuid format
         task = get_object_or_404(Task, id=pk, environment=env)
@@ -216,7 +215,6 @@ def get_task_log(request: HttpRequest, pk: str) -> HttpResponse:
         return HttpResponseNotFound("Unknown task submitted.")
 
     completed = task.status in FINISHED_STATUS
-    task_log = TaskLog.objects.get(task=task)
     show_output_selector = (
         False if not completed else _show_output_selector(task.result)
     )
@@ -225,7 +223,6 @@ def get_task_log(request: HttpRequest, pk: str) -> HttpResponse:
         "task": task,
         "completed": completed,
         "show_output_selector": show_output_selector,
-        "task_log": task_log.log,
         "output_format": "log",
     }
     return render(request, "partials/task_result_block.html", context)


### PR DESCRIPTION
Closes #141 and #142 

## Introduced Changes
- Added pagination navbar to the `TaskList` 
  - Created a pagination navbar partial so it can be re-used in other lists views
- Added button to `TaskDetail` to view the Task logs after the task has finished processing

## Testing
- View the `TaskList`, verify the pagination navbar is visible at the bottom
- View the `TastDetail`, wait for a task to finish executing, verify clicking the button to view logs returns the logs if they exist
