### PR TITLE
Move ScheduledTaskForm to its own file

### DIFF
--- a/functionary/ui/forms/__init__.py
+++ b/functionary/ui/forms/__init__.py
@@ -1,0 +1,2 @@
+from .scheduled_task import ScheduledTaskForm  # noqa
+from .tasks import TaskParameterForm  # noqa

--- a/functionary/ui/forms/scheduled_task.py
+++ b/functionary/ui/forms/scheduled_task.py
@@ -1,0 +1,122 @@
+from django.forms import CharField, ModelForm, ValidationError
+from django.urls import reverse
+from django_celery_beat.validators import (
+    day_of_month_validator,
+    day_of_week_validator,
+    hour_validator,
+    minute_validator,
+    month_of_year_validator,
+)
+
+from core.models import Environment, Function, ScheduledTask
+
+
+class ScheduledTaskForm(ModelForm):
+    scheduled_minute = CharField(
+        max_length=60 * 4, label="Minute", initial="*", validators=[minute_validator]
+    )
+    scheduled_hour = CharField(
+        max_length=24 * 4, label="Hour", initial="*", validators=[hour_validator]
+    )
+    scheduled_day_of_week = CharField(
+        max_length=64,
+        label="Day of Week",
+        initial="*",
+        validators=[day_of_week_validator],
+    )
+    scheduled_day_of_month = CharField(
+        max_length=31 * 4,
+        label="Day of Month",
+        initial="*",
+        validators=[day_of_month_validator],
+    )
+    scheduled_month_of_year = CharField(
+        max_length=64,
+        label="Month of Year",
+        initial="*",
+        validators=[month_of_year_validator],
+    )
+
+    class Meta:
+        model = ScheduledTask
+        fields = [
+            "name",
+            "description",
+            "status",
+            "function",
+            "parameters",
+            "environment",
+        ]
+
+    def __init__(self, *args, **kwargs):
+        env: Environment = kwargs.pop("env")
+        super().__init__(*args, **kwargs)
+        self.fields["function"].queryset = Function.objects.filter(
+            package__environment=env
+        )
+        self.fields["status"].choices = self._get_status_choices()
+        self._setup_field_classes()
+
+    def clean(self):
+        cleaned_data = super().clean()
+        available_functions = Function.objects.filter(
+            package__environment=cleaned_data["environment"]
+        )
+        if cleaned_data["function"] not in available_functions:
+            self.add_error(
+                "function",
+                ValidationError("Unknown function was provided.", code="invalid"),
+            )
+
+        return cleaned_data
+
+    def _get_status_choices(self) -> list:
+        choices = []
+        for choice in ScheduledTask.STATUS_CHOICES:
+            if choice[0] == ScheduledTask.PENDING or choice[0] == ScheduledTask.ERROR:
+                continue
+            choices.append(choice)
+        return choices
+
+    def _setup_field_classes(self):
+        for field in self.fields:
+            self.fields[field].widget.attrs.update({"class": "input is-medium"})
+
+        self.fields["name"].widget.attrs.update(
+            {"class": "input is-medium is-fullwidth"}
+        )
+
+        self.fields["status"].widget.attrs.update(
+            {"class": "input is-medium is-fullwidth"}
+        )
+
+        self.fields["function"].widget.attrs.update(
+            {
+                "hx-get": reverse("ui:function-parameters"),
+                "hx-target": "#function-parameters",
+            }
+        )
+
+        self._setup_crontab_fields()
+
+    def _setup_crontab_fields(self):
+        """Ugly method to attach htmx properties to the crontab components"""
+
+        crontab_fields = [
+            "scheduled_minute",
+            "scheduled_hour",
+            "scheduled_day_of_week",
+            "scheduled_day_of_month",
+            "scheduled_month_of_year",
+        ]
+
+        for field in crontab_fields:
+            field_id = f"id_{field}"
+            field_url = field.replace("_", "-")
+            self.fields[field].widget.attrs.update(
+                {
+                    "hx-post": reverse(f"ui:{field_url}-param"),
+                    "hx-trigger": "keyup delay:500ms",
+                    "hx-target": f"#{field_id}_errors",
+                }
+            )

--- a/functionary/ui/forms/tasks.py
+++ b/functionary/ui/forms/tasks.py
@@ -1,30 +1,19 @@
 import json
+from typing import Tuple, Type
 
-from django.db.models.query import QuerySet
 from django.forms import (
     BooleanField,
     CharField,
     DateField,
     DateTimeField,
+    Field,
     FloatField,
     Form,
     IntegerField,
     JSONField,
-    ModelForm,
     Textarea,
-    ValidationError,
 )
-from django.forms.widgets import DateInput, DateTimeInput
-from django.urls import reverse
-from django_celery_beat.validators import (
-    day_of_month_validator,
-    day_of_week_validator,
-    hour_validator,
-    minute_validator,
-    month_of_year_validator,
-)
-
-from core.models import Environment, Function, ScheduledTask
+from django.forms.widgets import DateInput, DateTimeInput, Widget
 
 
 class HTMLDateInput(DateInput):
@@ -96,24 +85,36 @@ def _prepare_initial_value(param_type, initial):
     return None
 
 
-def get_available_functions(env: Environment) -> QuerySet[Function]:
-    return Function.objects.filter(package__environment=env)
-
-
 class TaskParameterForm(Form):
+    """Form for providing task parameter input.
+
+    Dynamically generates a form based on the provided Function. The schema for the
+    Function is parsed and the appropriate fields are setup, including default values
+    and correct input types to be used for validation.
+
+    Attributes:
+        function: Function instance for which to generate the form
+        data: dict of data submitted to the form
+        initial: dict of initial values that the form fields should be populated with
+        prefix: Prefix to apply to the form field ids. Set this if the default value
+                happens to cause conflicts with other fields when using multiple forms.
+    """
+
     template_name = "forms/task_parameters.html"
 
     def __init__(self, function, data=None, initial=None, prefix="task-parameter"):
-        super().__init__(data, prefix=prefix)
+        super().__init__(data=data, prefix=prefix)
 
         if initial is None:
             initial = {}
 
         for param, value in function.schema["properties"].items():
             initial_value = initial.get(param, None) or value.get("default", None)
+            input_value = data.get(f"{self.prefix}-{param}") if data else None
             req = initial_value is None
             param_type = _get_param_type(value)
-            field_class, widget = _field_mapping.get(param_type, (None, None))
+
+            field_class, widget = self._get_field_info(param_type, input_value)
 
             if not field_class:
                 raise ValueError(f"Unknown field type for {param}: {param_type}")
@@ -136,109 +137,12 @@ class TaskParameterForm(Form):
                 field.widget.attrs.update({"class": "input"})
             self.fields[param] = field
 
-
-class ScheduledTaskForm(ModelForm):
-    scheduled_minute = CharField(
-        max_length=60 * 4, label="Minute", initial="*", validators=[minute_validator]
-    )
-    scheduled_hour = CharField(
-        max_length=24 * 4, label="Hour", initial="*", validators=[hour_validator]
-    )
-    scheduled_day_of_week = CharField(
-        max_length=64,
-        label="Day of Week",
-        initial="*",
-        validators=[day_of_week_validator],
-    )
-    scheduled_day_of_month = CharField(
-        max_length=31 * 4,
-        label="Day of Month",
-        initial="*",
-        validators=[day_of_month_validator],
-    )
-    scheduled_month_of_year = CharField(
-        max_length=64,
-        label="Month of Year",
-        initial="*",
-        validators=[month_of_year_validator],
-    )
-
-    class Meta:
-        model = ScheduledTask
-        fields = [
-            "name",
-            "description",
-            "status",
-            "function",
-            "parameters",
-            "environment",
-        ]
-
-    def __init__(self, *args, **kwargs):
-        env: Environment = kwargs.pop("env")
-        super().__init__(*args, **kwargs)
-        self.fields["function"].queryset = get_available_functions(env)
-        self.fields["status"].choices = self._get_status_choices()
-        self._setup_field_classes()
-
-    def clean(self):
-        cleaned_data = super().clean()
-        available_functions = get_available_functions(cleaned_data["environment"])
-        if cleaned_data["function"] not in available_functions:
-            self.add_error(
-                "function",
-                ValidationError("Unknown function was provided.", code="invalid"),
-            )
-
-        return cleaned_data
-
-    def _get_status_choices(self) -> list:
-        choices = []
-        for choice in ScheduledTask.STATUS_CHOICES:
-            if choice[0] == ScheduledTask.PENDING or choice[0] == ScheduledTask.ERROR:
-                continue
-            choices.append(choice)
-        return choices
-
-    def _setup_field_classes(self):
-        for field in self.fields:
-            self.fields[field].widget.attrs.update({"class": "input is-medium"})
-
-        self.fields["name"].widget.attrs.update(
-            {"class": "input is-medium is-fullwidth"}
-        )
-
-        self.fields["status"].widget.attrs.update(
-            {"class": "input is-medium is-fullwidth"}
-        )
-
-        self.fields["function"].widget.attrs.update(
-            {
-                "hx-get": reverse("ui:function-parameters"),
-                "hx-target": "#function-parameters",
-            }
-        )
-
-        self._setup_crontab_fields()
-
-    def _setup_crontab_fields(self):
-        """Ugly method to attach htmx properties to the crontab components"""
-
-        crontab_fields = [
-            "scheduled_minute",
-            "scheduled_hour",
-            "scheduled_day_of_week",
-            "scheduled_day_of_month",
-            "scheduled_month_of_year",
-        ]
-
-        for field in crontab_fields:
-            field_id = f"id_{field}"
-            field_url = field.replace("_", "-")
-            self.fields[field].widget.attrs.update(
-                {
-                    "hx-post": reverse(f"ui:{field_url}-param"),
-                    "hx-trigger": "keyup delay:500ms",
-                    "hx-target": f"#{field_id}_errors",
-                }
-            )
+    def _get_field_info(
+        self, parameter_type: str, input_value: str | None
+    ) -> Tuple[Type[Field], Type[Widget]]:
+        """Gets the appropriate field class and widget for the provided parameter type.
+        The input_value is not used in this implementation, but is expected to be
+        provided so that alternative implementations of this method can use it to derive
+        the field class and widget based on the input data.
+        """
+        return _field_mapping.get(parameter_type, (None, None))

--- a/functionary/ui/views/scheduling.py
+++ b/functionary/ui/views/scheduling.py
@@ -23,8 +23,8 @@ from core.utils.scheduling import (
     is_valid_scheduled_minute,
     is_valid_scheduled_month_of_year,
 )
+from ui.forms import ScheduledTaskForm, TaskParameterForm
 
-from ..forms.tasks import ScheduledTaskForm, TaskParameterForm, get_available_functions
 from .view_base import (
     PermissionedEnvironmentListView,
     PermissionedFormCreateView,
@@ -44,8 +44,8 @@ class ScheduledTaskCreateView(PermissionedFormCreateView):
     template_name = "core/scheduled_task_create.html"
 
     def get(self, *args, **kwargs):
-        env = Environment.objects.get(id=self.request.session.get("environment_id"))
-        if not len(get_available_functions(env)):
+        environment_id = self.request.session.get("environment_id")
+        if not Function.objects.filter(package__environment=environment_id).exists():
             messages.warning(
                 self.request,
                 "No available functions to schedule in current environment.",


### PR DESCRIPTION
This PR does two things:

* Moves ScheduledTaskForm into its own file
* Makes it possible to override the field type mapping in TaskParameterForm, in preparation for some work to come related to Workflows.

## Testing Instructions
* Verify that it is still possible to create / edit scheduled tasks.
* NOTE: There are some bugs related to scheduled tasks (json fields do not work, warning message displays twice, maybe others), but there should be no new bugs introduced by this change.