### PR TITLE
Fix the missing execute button on some functions.

### DIFF
--- a/functionary/ui/templates/core/function_detail.html
+++ b/functionary/ui/templates/core/function_detail.html
@@ -59,40 +59,36 @@
                 <span class="ml-4">{{ function.return_type }}</span>
             </div>
         {% endif %}
-        {% if function.output_format %}
-            <div class="field ml-4">
-                <label class="label" for="desc">Output Format:</label>
-                <span class="ml-4">{{ function.output_format }}</span>
-            </div>
-        {% endif %}
-        {% if form %}
+        {% if form is not None %}
             <div class="field ml-4">
                 <label class="label">Create Task:</label>
-                <div class="has-background-white-ter ml-4">
+                <div class="ml-4">
                     <form id="djangoForm"
                           method="post"
                           action="{% url 'ui:function-execute' %}">
                         {% csrf_token %}
-                        <input type="hidden" name="function_id" value="{{ function.id }}"/>
-                        <div class="column has-addons">
-                            {{ form.non_field_errors }}
-                            {{ form }}
-                            {% if missing_variables %}
-                                <div class="field ml-4 missing-variables has-background-danger-light has-text-danger">
-                                    <span>Tasking this function may not work as expected; the following variables are missing:</span>
-                                    <ul>
-                                        {% for missing in missing_variables %}
-                                            <li>
-                                                <span>{{ missing }}</span>
-                                            </li>
-                                        {% endfor %}
-                                    </ul>
-                                </div>
-                            {% endif %}
-                            <input class="button {% if missing_variables %}is-warning{% else %}is-link{% endif %}"
-                                   type="submit"
-                                   value="Execute"/>
+                        <div class="has-background-white-ter">
+                            <input type="hidden" name="function_id" value="{{ function.id }}"/>
+                            <div class="column has-addons">
+                                {{ form.non_field_errors }}
+                                {{ form }}
+                                {% if missing_variables %}
+                                    <div class="field ml-4 missing-variables has-background-danger-light has-text-danger">
+                                        <span>Tasking this function may not work as expected; the following variables are missing:</span>
+                                        <ul>
+                                            {% for missing in missing_variables %}
+                                                <li>
+                                                    <span>{{ missing }}</span>
+                                                </li>
+                                            {% endfor %}
+                                        </ul>
+                                    </div>
+                                {% endif %}
+                            </div>
                         </div>
+                        <input class="button mt-2 {% if missing_variables %}is-warning{% else %}is-link{% endif %}"
+                               type="submit"
+                               value="Execute"/>
                     </form>
                 </div>
             </div>

--- a/functionary/ui/views/functions.py
+++ b/functionary/ui/views/functions.py
@@ -38,6 +38,7 @@ class FunctionDetailView(PermissionedEnvironmentDetailView):
         context = super().get_context_data(**kwargs)
         function = self.object
         env = function.package.environment
+        form = None
 
         missing_variables = []
         if function.variables:
@@ -49,7 +50,7 @@ class FunctionDetailView(PermissionedEnvironmentDetailView):
         if self.request.user.has_perm(Permission.TASK_CREATE, env):
             form = TaskParameterForm(function)
 
-            context["form"] = form.render("forms/task_parameters.html")
+        context["form"] = form.render("forms/task_parameters.html") if form else None
         return context
 
 


### PR DESCRIPTION
While trying to fix a previous layout issue when a user didn't have permissions to task a function, the execute button was accidentally hidden for functions without parameters. This shows the button properly.

The old code for displaying the now defunct `output_format` for functions was also removed.