### PR TITLE
Add a vscode debug task for the django shell

### DIFF
--- a/functionary/.vscode/launch.json
+++ b/functionary/.vscode/launch.json
@@ -58,6 +58,16 @@
       "envFile": "${workspaceFolder}/.vscode/.debug.env",
       "django": true,
       "justMyCode": false
+    },
+    {
+      "name": "shell",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/manage.py",
+      "args": ["shell"],
+      "envFile": "${workspaceFolder}/.vscode/.debug.env",
+      "django": true,
+      "justMyCode": true
     }
   ]
 }


### PR DESCRIPTION
Adds a vscode debug launcher for the django shell so that it's easier to do some debugging via an interactive shell.