### PR TITLE
#161 - Fixed serialization issues during validation

### DIFF
--- a/functionary/core/models/scheduled_task.py
+++ b/functionary/core/models/scheduled_task.py
@@ -1,5 +1,6 @@
 """ Scheduled Task model """
 import uuid
+from json import JSONDecodeError
 
 import jsonschema
 from django.conf import settings
@@ -9,6 +10,7 @@ from django.db import models
 from django_celery_beat.models import CrontabSchedule, PeriodicTask
 
 from core.models import ModelSaveHookMixin
+from core.utils.serialization import serialize_parameters
 
 
 class ScheduledTask(ModelSaveHookMixin, models.Model):
@@ -92,12 +94,15 @@ class ScheduledTask(ModelSaveHookMixin, models.Model):
     def _clean_parameters(self):
         """Validate that the parameters conform to the function's schema"""
         try:
+            parameters = serialize_parameters(self.parameters, self.function.schema)
             jsonschema.validate(
-                instance=self.parameters,
+                instance=parameters,
                 schema=self.function.schema,
             )
         except jsonschema.ValidationError as exc:
             raise ValidationError(exc.message)
+        except JSONDecodeError as err:
+            raise ValidationError(err.msg)
 
     def clean(self):
         """Model instance validation and attribute cleanup"""

--- a/functionary/core/utils/serialization.py
+++ b/functionary/core/utils/serialization.py
@@ -1,0 +1,90 @@
+from copy import deepcopy
+from json import JSONDecodeError, dumps, loads
+from typing import Union
+
+# Place helper methods for serializing data that is used by the models in here
+# Don't import any models to prevent cyclic module dependencies
+
+
+def serialize_parameters(parameters: dict, schema: dict) -> Union[dict, None]:
+    """JSON stringify parameters which are supposed to be JSON formatted strings
+
+    Iterate throw the given schema to find any function arguments that
+    could be JSON formatted strings. If so, dump the value of that argument
+    into a JSON string, and overwrite that value in a deep copy of the
+    given parameters dictionary.
+    Perform the same logic if the function argument can be multiple different
+    types, as indicated by 'anyOf'.
+    Returns a deep copy of the parameters that contains all of the serialized
+    JSON fields.
+
+    NOTE: This function does not handle nested schemas past the function
+    argument->anyOf[{}, {}, ...]. If the function schemas need to include more
+    nesting, this will need to be reworked.
+
+    Args:
+        parameters: A dictionary that contains the parameters for the function.
+            Example format looks like {'a': 1, 'b': 2}
+        schema: A dictionary that represents the JSON schema for the function
+
+    Returns:
+        parameters: A new dictionary that contains all of the serialized
+            function arguments.
+    """
+    if not parameters:
+        return {}
+
+    parameters_copy = deepcopy(parameters)
+    try:
+        for arg, param_type in schema["properties"].items():
+            if union_type_param := param_type.get("anyOf"):
+                serialize_union_parameters(arg, union_type_param, parameters_copy)
+            else:
+                if is_json_field(param_type):
+                    parameters_copy[arg] = dumps(parameters_copy[arg])
+                    # Validate the serialized JSON string is valid JSON
+                    _ = loads(parameters_copy[arg])
+        return parameters_copy
+    except JSONDecodeError as err:
+        raise err
+
+
+def serialize_union_parameters(
+    arg: str, union_type_param: dict, parameters: dict
+) -> None:
+    """Mutate given parameters dictionary to json stringify the parameters"""
+    for param_type in union_type_param:
+        if is_json_field(param_type):
+            parameters[arg] = dumps(parameters[arg])
+            _ = loads(parameters[arg])
+
+
+def json_stringify_parameters(parameters: dict) -> str:
+    """Turns the values of the dictionary keys into JSON strings
+
+    Creates a new dictionary from the given dictionary and serializes each item
+    for each key into a JSON string. This is necessary for the JSONField defined
+    in the Task model.
+
+    Args:
+        parameters: A dictionary containing all the parameters for a Task
+
+    Returns:
+        params: A dictionary whose values are all JSON formatted strings
+
+    Raises:
+        JSONDecodeError: If one of the values in the parameters cannot be serialized
+        into a JSON string, raise a JSONDecodeError
+    """
+    params = {}
+    try:
+        for key, value in parameters.items():
+            json_stringified_params = dumps(value)
+            params[key] = json_stringified_params
+        return params
+    except JSONDecodeError as err:
+        raise err
+
+
+def is_json_field(param: dict) -> bool:
+    return "json-string" == param.get("format")

--- a/functionary/core/utils/serialization.py
+++ b/functionary/core/utils/serialization.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from json import JSONDecodeError, dumps, loads
+from json import JSONDecodeError, dumps
 
 # Place helper methods for serializing data that is used by the models in here
 # Don't import any models to prevent cyclic module dependencies
@@ -41,26 +41,23 @@ def serialize_parameters(parameters: dict, schema: dict) -> dict:
     try:
         for arg, param_type in schema["properties"].items():
             if union_type_param := param_type.get("anyOf"):
-                serialize_union_parameters(arg, union_type_param, parameters_copy)
+                _serialize_union_parameters(arg, union_type_param, parameters_copy)
             else:
-                if is_json_field(param_type):
+                if _is_json_field(param_type):
                     parameters_copy[arg] = dumps(parameters_copy[arg])
-                    # Validate the serialized JSON string is valid JSON
-                    _ = loads(parameters_copy[arg])
         return parameters_copy
     except JSONDecodeError as err:
         raise err
 
 
-def serialize_union_parameters(
+def _serialize_union_parameters(
     arg: str, union_type_param: dict, parameters: dict
 ) -> None:
     """Mutate given parameters dictionary to json stringify the parameters"""
     for param_type in union_type_param:
-        if is_json_field(param_type):
+        if _is_json_field(param_type):
             parameters[arg] = dumps(parameters[arg])
-            _ = loads(parameters[arg])
 
 
-def is_json_field(param: dict) -> bool:
+def _is_json_field(param: dict) -> bool:
     return "json-string" == param.get("format")

--- a/functionary/core/utils/serialization.py
+++ b/functionary/core/utils/serialization.py
@@ -1,12 +1,11 @@
 from copy import deepcopy
 from json import JSONDecodeError, dumps, loads
-from typing import Union
 
 # Place helper methods for serializing data that is used by the models in here
 # Don't import any models to prevent cyclic module dependencies
 
 
-def serialize_parameters(parameters: dict, schema: dict) -> Union[dict, None]:
+def serialize_parameters(parameters: dict, schema: dict) -> dict:
     """JSON stringify parameters which are supposed to be JSON formatted strings
 
     Iterate throw the given schema to find any function arguments that
@@ -30,6 +29,10 @@ def serialize_parameters(parameters: dict, schema: dict) -> Union[dict, None]:
     Returns:
         parameters: A new dictionary that contains all of the serialized
             function arguments.
+
+    Raises:
+        JSONDecodeError: If a parameter is not valid JSON, a JSONDecodeError will
+            be raised.
     """
     if not parameters:
         return {}
@@ -57,33 +60,6 @@ def serialize_union_parameters(
         if is_json_field(param_type):
             parameters[arg] = dumps(parameters[arg])
             _ = loads(parameters[arg])
-
-
-def json_stringify_parameters(parameters: dict) -> str:
-    """Turns the values of the dictionary keys into JSON strings
-
-    Creates a new dictionary from the given dictionary and serializes each item
-    for each key into a JSON string. This is necessary for the JSONField defined
-    in the Task model.
-
-    Args:
-        parameters: A dictionary containing all the parameters for a Task
-
-    Returns:
-        params: A dictionary whose values are all JSON formatted strings
-
-    Raises:
-        JSONDecodeError: If one of the values in the parameters cannot be serialized
-        into a JSON string, raise a JSONDecodeError
-    """
-    params = {}
-    try:
-        for key, value in parameters.items():
-            json_stringified_params = dumps(value)
-            params[key] = json_stringified_params
-        return params
-    except JSONDecodeError as err:
-        raise err
 
 
 def is_json_field(param: dict) -> bool:

--- a/functionary/ui/templates/core/scheduled_task_create.html
+++ b/functionary/ui/templates/core/scheduled_task_create.html
@@ -117,7 +117,7 @@
                             <div class="column is-one-third">
                                 <div class="box">
                                     <label for="{{ form.scheduled_minute.id_for_label }}">
-                                        <span>{{ form.scheduled_minute.label}}</span>
+                                        <span>{{ form.scheduled_minute.label }}</span>
                                     </label>
                                     <div class="control">
                                         {{ form.scheduled_minute }}
@@ -130,7 +130,7 @@
                             <div class="column is-one-third">
                                 <div class="box">
                                     <label for="{{ form.scheduled_hour.id_for_label }}">
-                                        <span>{{ form.scheduled_hour.label}}</span>
+                                        <span>{{ form.scheduled_hour.label }}</span>
                                     </label>
                                     <div class="control">
                                         {{ form.scheduled_hour }}
@@ -143,7 +143,7 @@
                             <div class="column is-one-third">
                                 <div class="box">
                                     <label for="{{ form.scheduled_day_of_week.id_for_label }}">
-                                        <span>{{ form.scheduled_day_of_week.label}}</span>
+                                        <span>{{ form.scheduled_day_of_week.label }}</span>
                                     </label>
                                     <div class="control">
                                         {{ form.scheduled_day_of_week }}
@@ -156,7 +156,7 @@
                             <div class="column is-one-third">
                                 <div class="box">
                                     <label for="{{ form.scheduled_day_of_month.id_for_label }}">
-                                        <span>{{ form.scheduled_day_of_month.label}}</span>
+                                        <span>{{ form.scheduled_day_of_month.label }}</span>
                                     </label>
                                     <div class="control">
                                         {{ form.scheduled_day_of_month }}
@@ -169,7 +169,7 @@
                             <div class="column is-one-third">
                                 <div class="box">
                                     <label for="{{ form.scheduled_month_of_year.id_for_label }}">
-                                        <span>{{ form.scheduled_month_of_year.label}}</span>
+                                        <span>{{ form.scheduled_month_of_year.label }}</span>
                                     </label>
                                     <div class="control">
                                         {{ form.scheduled_month_of_year }}

--- a/functionary/ui/templates/core/scheduled_task_list.html
+++ b/functionary/ui/templates/core/scheduled_task_list.html
@@ -3,19 +3,6 @@
 {% block content %}
     <div>
 
-        <div class="columns is-centered">
-            <div class="column has-text-centered is-half">
-                {% if messages %}
-                {% for message in messages %}
-                <div class="notification is-warning">
-                    <button class="delete" onclick="return this.parentNode.remove();"></button>
-                    {{ message }}
-                </div>
-                {% endfor %}
-                {% endif %}
-            </div>
-        </div>
-
         <div class="level-right">
 
             <a href="{% url 'ui:new-schedule' %}">

--- a/functionary/ui/templates/core/scheduled_task_update.html
+++ b/functionary/ui/templates/core/scheduled_task_update.html
@@ -143,7 +143,7 @@
                             <div class="column is-one-third">
                                 <div class="box">
                                     <label for="{{ form.scheduled_minute.id_for_label }}">
-                                        <span>{{ form.scheduled_minute.label}}</span>
+                                        <span>{{ form.scheduled_minute.label }}</span>
                                     </label>
                                     <div class="control">
                                         {{ form.scheduled_minute }}
@@ -156,7 +156,7 @@
                             <div class="column is-one-third">
                                 <div class="box">
                                     <label for="{{ form.scheduled_hour.id_for_label }}">
-                                        <span>{{ form.scheduled_hour.label}}</span>
+                                        <span>{{ form.scheduled_hour.label }}</span>
                                     </label>
                                     <div class="control">
                                         {{ form.scheduled_hour }}
@@ -169,7 +169,7 @@
                             <div class="column is-one-third">
                                 <div class="box">
                                     <label for="{{ form.scheduled_day_of_week.id_for_label }}">
-                                        <span>{{ form.scheduled_day_of_week.label}}</span>
+                                        <span>{{ form.scheduled_day_of_week.label }}</span>
                                     </label>
                                     <div class="control">
                                         {{ form.scheduled_day_of_week }}
@@ -182,7 +182,7 @@
                             <div class="column is-one-third">
                                 <div class="box">
                                     <label for="{{ form.scheduled_day_of_month.id_for_label }}">
-                                        <span>{{ form.scheduled_day_of_month.label}}</span>
+                                        <span>{{ form.scheduled_day_of_month.label }}</span>
                                     </label>
                                     <div class="control">
                                         {{ form.scheduled_day_of_month }}
@@ -195,7 +195,7 @@
                             <div class="column is-one-third">
                                 <div class="box">
                                     <label for="{{ form.scheduled_month_of_year.id_for_label }}">
-                                        <span>{{ form.scheduled_month_of_year.label}}</span>
+                                        <span>{{ form.scheduled_month_of_year.label }}</span>
                                     </label>
                                     <div class="control">
                                         {{ form.scheduled_month_of_year }}

--- a/functionary/ui/urls.py
+++ b/functionary/ui/urls.py
@@ -141,6 +141,11 @@ htmx_urlpatterns = [
         name="new-schedule",
     ),
     path(
+        "create_schedule/",
+        (scheduling.create_scheduled_task),
+        name="create-schedule",
+    ),
+    path(
         "update_schedule/<uuid:pk>",
         (scheduling.update_scheduled_task),
         name="update-schedule",

--- a/functionary/ui/views/scheduling.py
+++ b/functionary/ui/views/scheduling.py
@@ -273,9 +273,13 @@ def crontab_month_of_year_param(request: HttpRequest) -> HttpResponse:
 def _create_scheduled_task(
     request: HttpRequest, schedule_form_data: dict, task_params: dict
 ):
-    """Helper function for creating scheduled task"""
+    """Helper function for creating scheduled task
+
+    By this point, the parameters have been validated against the schema,
+    and the fields have been validated, so we can just create the object.
+    """
     with transaction.atomic():
-        scheduled_task = ScheduledTask(
+        scheduled_task = ScheduledTask.objects.create(
             name=schedule_form_data["name"],
             environment=schedule_form_data["environment"],
             description=schedule_form_data["description"],
@@ -283,10 +287,6 @@ def _create_scheduled_task(
             parameters=task_params,
             creator=request.user,
         )
-        # Don't need try/except here since all fields would have been validated during
-        # the <model>form.is_valid()
-        scheduled_task.clean()
-        scheduled_task.save()
         crontab_schedule = _get_crontab_schedule(schedule_form_data)
         scheduled_task.set_schedule(crontab_schedule)
         scheduled_task.activate()

--- a/functionary/ui/views/tasks.py
+++ b/functionary/ui/views/tasks.py
@@ -121,8 +121,8 @@ def _format_result(result, format):
     return output_format, format_error, formatted_result
 
 
-def _get_result_context(context, format):
-    task = context["task"]
+def _get_result_context(context: dict, format: str) -> dict:
+    task: Task = context["task"]
 
     completed = task.status in FINISHED_STATUS
 


### PR DESCRIPTION
Closes #161 

## Introduced Changes
- Added new util to handle serialization of python dictionaries to JSON strings
  - This utility is used to create a new dictionary of a Task or ScheduledTask parameters, which is what the JSON Schema Validator will use to validate the parameters conform to the function's schema
- Removed the `_prepare_initial_value` function in the Tasks.py since it was really only ever looking for a JSON field to run `loads`. Now, in the `__init__()` of the `TaskParameterForm`, the form just uses the value from initial.
- Added some missing type hints
- Fixed some linting complaints
- Fixed missing ScheduledTask url for form submission
- Removed `obj = *.objects.create()` in favor of `obj = Object() -> obj.clean()  -> obj.save()`
- Removed extra message display in ScheduledTask list in favor of the message display used by the auth templates


## Testing
- Run some functions with valid and invalid parameters. Ensure you are getting appropriate errors.
- Create and Update some ScheduledTasks. Verify the Schedules are validating the input

## Notes
- The serialization function for the parameters is limited to the current nesting amount as shown in the `output_json` example schema. If we ever want to include more nesting in the schema, the serialization function will need to be updated to a more dynamic solution