### PR TITLE
#143 - Workflow Steps UI

### DIFF
--- a/functionary/ui/forms/__init__.py
+++ b/functionary/ui/forms/__init__.py
@@ -1,2 +1,3 @@
 from .scheduled_task import ScheduledTaskForm  # noqa
-from .tasks import TaskParameterForm  # noqa
+from .tasks import TaskParameterForm, TaskParameterTemplateForm  # noqa
+from .workflow_step import WorkflowStepCreateForm, WorkflowStepUpdateForm  # noqa

--- a/functionary/ui/forms/tasks.py
+++ b/functionary/ui/forms/tasks.py
@@ -48,7 +48,11 @@ _field_mapping = {
 
 def _transform_json(value: Union[str, dict]) -> Union[str, dict]:
     if type(value) is str:
-        return json.loads(value)
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            pass
+
     return value
 
 
@@ -194,7 +198,7 @@ class TaskParameterTemplateForm(TaskParameterForm):
         self,
         function: "Function",
         data: Optional["QueryDict"] = None,
-        initial: str | None = None,
+        initial: Optional[str] = None,
     ):
         """TaskParameterTemplateForm init
 

--- a/functionary/ui/forms/tasks.py
+++ b/functionary/ui/forms/tasks.py
@@ -1,5 +1,6 @@
 import json
-from typing import Tuple, Type, Union
+import re
+from typing import TYPE_CHECKING, Optional, Tuple, Type, Union
 
 from django.forms import (
     BooleanField,
@@ -12,10 +13,14 @@ from django.forms import (
     IntegerField,
     JSONField,
     Textarea,
+    TextInput,
 )
 from django.forms.widgets import DateInput, DateTimeInput, Widget
 
-from core.models import Function
+if TYPE_CHECKING:
+    from django.http import QueryDict
+
+    from core.models import Function
 
 
 class HTMLDateInput(DateInput):
@@ -112,9 +117,9 @@ class TaskParameterForm(Form):
 
     def __init__(
         self,
-        function: Function,
-        data: dict = None,
-        initial: dict = None,
+        function: "Function",
+        data: dict | None = None,
+        initial: dict | None = None,
         prefix: str = "task-parameter",
     ):
         super().__init__(data=data, prefix=prefix)
@@ -128,7 +133,7 @@ class TaskParameterForm(Form):
             req = initial_value is None
             param_type = _get_param_type(value)
 
-            field_class, widget = self._get_field_info(param_type, input_value)
+            field_class, widget = self.get_field_info(param_type, input_value)
 
             if not field_class:
                 raise ValueError(f"Unknown field type for {param}: {param_type}")
@@ -151,7 +156,7 @@ class TaskParameterForm(Form):
                 field.widget.attrs.update({"class": "input"})
             self.fields[param] = field
 
-    def _get_field_info(
+    def get_field_info(
         self, parameter_type: str, input_value: str | None
     ) -> Tuple[Type[Field], Type[Widget]]:
         """Gets the appropriate field class and widget for the provided parameter type.
@@ -160,3 +165,76 @@ class TaskParameterForm(Form):
         the field class and widget based on the input data.
         """
         return _field_mapping.get(parameter_type, (None, None))
+
+
+class TaskParameterTemplateForm(TaskParameterForm):
+    """TaskParameterForm variant with template variable support
+
+    This is a version of TaskParameterForm that allows template variables to be entered
+    as values regardless of parameter type. That is, a field requiring an integer will
+    allow either and integer value or a template variable such as {{step.result}}.
+    Other than the exception for template variables, other validation rules still apply.
+    """
+
+    def _stringify_template_variables(self, parameter_template: str) -> str:
+        """Converts the template variables in the parameter template to strings so
+        that the template can be safely jsonified.
+        """
+        return re.sub(r"{{([\w\.]+)}}", r'"{{\1}}"', parameter_template)
+
+    def _build_parameter_template(self, parameters: dict) -> str:
+        """Undo the template variable stringification that was required to jsonify
+        the template. The resulting string is one that can be rendered as a django
+        template"""
+        json_data = json.dumps(parameters)
+
+        return re.sub(r'"{{([\w\.]*)}}"', r"{{\1}}", json_data)
+
+    def __init__(
+        self,
+        function: "Function",
+        data: Optional["QueryDict"] = None,
+        initial: str | None = None,
+    ):
+        """TaskParameterTemplateForm init
+
+        Args:
+            function: The Function that will be executed when the WorkflowStep runs
+            data: Form submission data
+            initial: Initial values to populate the form fields with on render
+        """
+        initial_data = (
+            json.loads(self._stringify_template_variables(initial)) if initial else {}
+        )
+
+        super().__init__(function=function, data=data, initial=initial_data)
+
+    def get_field_info(
+        self, parameter_type: str, input_value: str | None
+    ) -> Tuple[Type[Field], Type[Widget]]:
+        """For fields that are allowed to provide template variables as input, alters
+        the widget to be a TextInput. When input_value is provided, if the input is a
+        template variable the field class is set to CharField, as validation against the
+        original field class is no longer possible.
+        """
+        field_class, widget = super().get_field_info(parameter_type, input_value)
+
+        if parameter_type in ["integer", "number", "json"]:
+            widget = TextInput
+
+            if input_value and re.match(r"{{[\w\.]+}}", input_value):
+                field_class = CharField
+
+        return field_class, widget
+
+    @property
+    def parameter_template(self):
+        """Returns the json-string parameter template for parameters form. This can
+        only be access after validation via is_valid().
+        """
+        assert hasattr(self, "cleaned_data"), (
+            "You cannot access parameter_template until cleaned_data is made available"
+            "by calling is_valid()."
+        )
+
+        return self._build_parameter_template(self.cleaned_data)

--- a/functionary/ui/forms/workflow_step.py
+++ b/functionary/ui/forms/workflow_step.py
@@ -1,0 +1,63 @@
+from typing import TYPE_CHECKING, Optional
+
+from django import forms
+from django.urls import reverse
+
+from core.models import WorkflowStep
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from core.models import Environment
+
+
+class WorkflowStepCreateForm(forms.ModelForm):
+    """Form for WorkflowStep creation"""
+
+    template_name = "forms/workflows/step_edit.html"
+
+    class Meta:
+        model = WorkflowStep
+        fields = ["workflow", "name", "function", "next"]
+        widgets = {"workflow": forms.HiddenInput(), "next": forms.HiddenInput()}
+
+    def __init__(
+        self,
+        environment: Optional["Environment"] | "UUID" | str = None,
+        *args,
+        **kwargs
+    ):
+        """WorkflowStepForm init
+
+        Args:
+            environment: Environment instance or id. When provided, the queryset of the
+                function field will be filtered to only the functions for the
+                environment.
+        """
+        super().__init__(*args, **kwargs)
+
+        # Add htmx attributes to the function widget
+        self.fields["function"].widget.attrs.update(
+            {
+                "class": "input",
+                "hx-get": reverse("ui:function-parameters"),
+                "hx-vals": '{"allow_template_variables": "true"}',
+                "hx-target": "#function-parameters",
+                "hx-swap": "innerHTML",
+            }
+        )
+
+        # Narrow the available function list down to just those for the environment
+        if environment is not None:
+            function_field = self.fields["function"]
+            function_field.queryset = function_field.queryset.filter(
+                package__environment=environment
+            )
+
+
+class WorkflowStepUpdateForm(WorkflowStepCreateForm):
+    """Form for WorkflowStep updates"""
+
+    class Meta:
+        model = WorkflowStep
+        fields = ["name", "function"]

--- a/functionary/ui/forms/workflow_step.py
+++ b/functionary/ui/forms/workflow_step.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Union
 
 from django import forms
 from django.urls import reverse
@@ -23,7 +23,7 @@ class WorkflowStepCreateForm(forms.ModelForm):
 
     def __init__(
         self,
-        environment: Optional["Environment"] | "UUID" | str = None,
+        environment: Union["Environment", "UUID", str, None] = None,
         *args,
         **kwargs
     ):

--- a/functionary/ui/templates/core/scheduled_task_update.html
+++ b/functionary/ui/templates/core/scheduled_task_update.html
@@ -229,8 +229,8 @@
                                 {% endif %}
                             </div>
                         </div>
-                        <!-- Lazy load function parameters -->
-                        <div class="column" id="function-parameters" hx-trigger="load" hx-get="{% url 'ui:function-parameters' %}" hx-vals='{"function": "{{ function_id }}", "scheduled_task_id": "{{ scheduled_task_id }}"}'>
+                        <div class="column" id="function-parameters">
+                            {% include "forms/task_parameters.html" with form=parameter_form %}
                         </div>
                     </div>
                 </div>

--- a/functionary/ui/templates/core/workflow_detail.html
+++ b/functionary/ui/templates/core/workflow_detail.html
@@ -20,4 +20,5 @@
     <hr/>
     <div class="block">{% include "partials/workflows/parameter_list.html" %}</div>
     <hr/>
+    <div class="block">{% include "partials/workflows/step_list.html" %}</div>
 {% endblock content %}

--- a/functionary/ui/templates/forms/workflows/step_edit.html
+++ b/functionary/ui/templates/forms/workflows/step_edit.html
@@ -1,0 +1,43 @@
+{# djlint: off #}
+{% extends "partials/modal.html" %}
+{% load widget_tweaks %}
+
+{% block modal_title %}
+    Workflow Step
+{% endblock modal_title %}
+
+{% block form_declaration %}
+    {% if workflowstep %}
+        <form id="step-form" method="post" hx-post="{% url 'ui:workflowstep-edit' view.kwargs.workflow_pk workflowstep.pk %}" hx-target="#form-modal" hx-swap="outerHTML">
+    {% else %}
+        <form id="step-form" method="post" hx-post="{% url 'ui:workflowstep-create' view.kwargs.workflow_pk %}" hx-target="#form-modal" hx-swap="outerHTML">
+    {% endif %}
+{% endblock form_declaration %}
+
+{% block modal_content %}
+    <div class="field">
+        <label class="label" for="{{ form.name.id_for_label }}">{{ form.name.label }}</label>
+        <div class="control">{% render_field form.name class="input" %}</div>
+        <div>{{ form.non_field_errors }}</div>
+        <div>{{ form.name.errors }}</div>
+    </div>
+    <div class="field">
+        <label class="label" for="{{ form.function.id_for_label }}">{{ form.function.label }}</label>
+        <div class="control select">{{ form.function }}</div>
+        <div>{{ form.function.errors }}</div>
+    </div>
+    <div class="field">
+        <div id="function-parameters">{{ parameter_form }}</div>
+    </div>
+    <div>{{form.workflow}}</div>
+    <div>{{form.next}}</div>
+{% endblock modal_content %}
+
+{% block modal_footer %}
+    <button class="button" type="submit" value="Save">Save</button>
+{% endblock modal_footer %}
+
+{% block form_end %}
+    </form>
+{% endblock form_end %}
+{# djlint: on #}

--- a/functionary/ui/templates/partials/workflows/step_list.html
+++ b/functionary/ui/templates/partials/workflows/step_list.html
@@ -1,0 +1,52 @@
+<div id="workflow-steps">
+    <h2 class="title is-4">Steps</h2>
+    <!--TODO: A table is not really suitable for this data. This is just a
+    placeholder to demonstrate the functionality-->
+    <table class="table is-striped">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Function</th>
+                <th>Parameters</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody id="steps">
+            {% for step in workflow.ordered_steps %}
+                <tr>
+                    <td>{{ step.name }}</td>
+                    <td>{{ step.function }}</td>
+                    <td class="json-container">{{ step.parameter_template }}</td>
+                    <td>
+                        <button class="button is-small mr-2 is-white has-text-success fa fa-plus"
+                                type="button"
+                                title="Add Step Below"
+                                hx-target="body"
+                                hx-swap="beforeend"
+                                hx-get="{% url 'ui:workflowstep-create' workflow.pk %}"
+                                hx-vals='{"next": "{{ step.next.id }}"}'/>
+                        <button class="button is-small mr-2 is-white has-text-info fa fa-pencil-alt"
+                                type="button"
+                                title="Edit"
+                                hx-target="body"
+                                hx-swap="beforeend"
+                                hx-get="{% url 'ui:workflowstep-edit' workflow.pk step.pk %}"/>
+                        <button class="button is-small is-white has-text-danger fa fa-trash"
+                                type="button"
+                                title="Delete"
+                                hx-target="#workflow-steps"
+                                hx-swap="outerHTML"
+                                hx-delete="{% url 'ui:workflowstep-delete' workflow.pk step.pk %}"/>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <button class="button is-small"
+            type="button"
+            hx-target="body"
+            hx-swap="beforeend"
+            hx-get="{% url 'ui:workflowstep-create' workflow.pk %}">
+        <span class="mr-2">Add</span><span class="fa fa-plus"/>
+    </button>
+</div>

--- a/functionary/ui/tests/forms/test_tasks.py
+++ b/functionary/ui/tests/forms/test_tasks.py
@@ -1,0 +1,41 @@
+import pytest
+
+from core.models import Function, Package, Team
+from ui.forms.tasks import TaskParameterTemplateForm
+
+
+@pytest.fixture
+def environment():
+    team = Team.objects.create(name="team")
+    return team.environments.get()
+
+
+@pytest.fixture
+def package(environment):
+    return Package.objects.create(name="testpackage", environment=environment)
+
+
+@pytest.fixture
+def function(package):
+    function_schema = {
+        "title": "test",
+        "type": "object",
+        "properties": {
+            "int_param": {"type": "integer", "title": "int_param"},
+            "json_param": {"type": "json", "title": "json_param"},
+        },
+    }
+    return Function.objects.create(
+        name="testfunction", package=package, schema=function_schema
+    )
+
+
+@pytest.mark.django_db
+def test_taskparametertemplateform_can_load_initial_values(function):
+    form = TaskParameterTemplateForm(
+        function=function,
+        initial='{"int_param": {{var1}}, "json_param": {{var2}}}',
+    )
+
+    assert form.fields["int_param"].initial == "{{var1}}"
+    assert form.fields["json_param"].initial == "{{var2}}"

--- a/functionary/ui/urls.py
+++ b/functionary/ui/urls.py
@@ -56,6 +56,11 @@ urlpatterns = [
     ),
     path("function_execute/", (functions.execute), name="function-execute"),
     path(
+        "function_parameters/",
+        (functions.function_parameters),
+        name="function-parameters",
+    ),
+    path(
         "package_list/",
         (packages.PackageListView.as_view()),
         name="package-list",
@@ -129,11 +134,6 @@ htmx_urlpatterns = [
         "crontab_month_of_year_param/",
         (scheduling.crontab_month_of_year_param),
         name="scheduled-month-of-year-param",
-    ),
-    path(
-        "function_parameters/",
-        (scheduling.function_parameters),
-        name="function-parameters",
     ),
     path(
         "new_schedule/",
@@ -256,6 +256,21 @@ workflows_urlpatterns = [
         "workflow/<uuid:workflow_pk>/parameter/<int:pk>/edit",
         (workflows.WorkflowParameterUpdateView.as_view()),
         name="workflowparameter-edit",
+    ),
+    path(
+        "workflow/<uuid:workflow_pk>/step/create",
+        (workflows.WorkflowStepCreateView.as_view()),
+        name="workflowstep-create",
+    ),
+    path(
+        "workflow/<uuid:workflow_pk>/step/<uuid:pk>/delete",
+        (workflows.WorkflowStepDeleteView.as_view()),
+        name="workflowstep-delete",
+    ),
+    path(
+        "workflow/<uuid:workflow_pk>/step/<uuid:pk>/edit",
+        (workflows.WorkflowStepUpdateView.as_view()),
+        name="workflowstep-edit",
     ),
 ]
 

--- a/functionary/ui/views/workflows/__init__.py
+++ b/functionary/ui/views/workflows/__init__.py
@@ -6,4 +6,7 @@ from .parameters.edit import (  # noqa
     WorkflowParameterCreateView,
     WorkflowParameterUpdateView,
 )
+from .steps.create import WorkflowStepCreateView  # noqa
+from .steps.delete import WorkflowStepDeleteView  # noqa
+from .steps.update import WorkflowStepUpdateView  # noqa
 from .update import WorkflowUpdateView  # noqa

--- a/functionary/ui/views/workflows/steps/create.py
+++ b/functionary/ui/views/workflows/steps/create.py
@@ -1,0 +1,71 @@
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
+from django.views.generic import CreateView
+from django_htmx.http import HttpResponseClientRedirect
+
+from core.auth import Permission
+from core.models import Function, Workflow, WorkflowStep
+from core.utils.workflow import add_step
+from ui.forms import TaskParameterTemplateForm, WorkflowStepCreateForm
+
+
+class WorkflowStepCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
+    """Create view for the WorkflowStep model"""
+
+    model = WorkflowStep
+    form_class = WorkflowStepCreateForm
+    template_name = WorkflowStepCreateForm.template_name
+
+    def get_initial(self):
+        """Populate initial form values"""
+        initial = super().get_initial()
+        initial["next"] = self.request.GET.get("next")
+        initial["workflow"] = self.kwargs.get("workflow_pk")
+
+        return initial
+
+    def get_form_kwargs(self):
+        """Setup kwargs for form instantiation"""
+        kwargs = super().get_form_kwargs()
+        kwargs["environment"] = self.request.session["environment_id"]
+
+        return kwargs
+
+    def post(self, request, workflow_pk):
+        """Handle WorkflowStepForm submission"""
+        # Various parent class calls require the object be set
+        self.object = None
+
+        function = Function.objects.get(id=self.request.POST.get("function"))
+        parameter_form = TaskParameterTemplateForm(
+            function=function, data=self.request.POST
+        )
+        step_form = self.get_form()
+
+        if step_form.is_valid() and parameter_form.is_valid():
+            step = add_step(
+                **step_form.cleaned_data,
+                parameter_template=parameter_form.parameter_template
+            )
+
+            success_url = reverse("ui:workflow-detail", kwargs={"pk": step.workflow.pk})
+
+            return HttpResponseClientRedirect(success_url)
+        else:
+            context = self.get_context_data()
+            context["parameter_form"] = parameter_form
+
+            return render(self.request, self.template_name, context)
+
+    def test_func(self):
+        """Permission check for view access"""
+        workflow = get_object_or_404(
+            Workflow,
+            pk=self.kwargs.get("workflow_pk"),
+            environment__id=self.request.session.get("environment_id"),
+        )
+
+        return self.request.user.has_perm(
+            Permission.WORKFLOW_UPDATE, workflow.environment
+        )

--- a/functionary/ui/views/workflows/steps/delete.py
+++ b/functionary/ui/views/workflows/steps/delete.py
@@ -1,0 +1,30 @@
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.shortcuts import get_object_or_404, render
+from django.views.generic import View
+
+from core.auth import Permission
+from core.models import WorkflowStep
+from core.utils.workflow import remove_step
+
+
+class WorkflowStepDeleteView(LoginRequiredMixin, UserPassesTestMixin, View):
+    """Delete view for the WorkflowStep model"""
+
+    def _get_object(self):
+        return get_object_or_404(
+            WorkflowStep,
+            workflow__pk=self.kwargs.get("workflow_pk"),
+            pk=self.kwargs.get("pk"),
+        )
+
+    def delete(self, request, workflow_pk, pk):
+        step = self._get_object()
+        context = {"workflow": step.workflow}
+        remove_step(step)
+
+        return render(request, "partials/workflows/step_list.html", context)
+
+    def test_func(self):
+        """Permission check for access to the view"""
+        env = self._get_object().workflow.environment
+        return self.request.user.has_perm(Permission.WORKFLOW_UPDATE, env)

--- a/functionary/ui/views/workflows/steps/update.py
+++ b/functionary/ui/views/workflows/steps/update.py
@@ -1,0 +1,65 @@
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.shortcuts import render
+from django.urls import reverse
+from django.views.generic import UpdateView
+from django_htmx.http import HttpResponseClientRedirect
+
+from core.auth import Permission
+from core.models import Function, WorkflowStep
+from ui.forms import TaskParameterTemplateForm, WorkflowStepUpdateForm
+
+
+class WorkflowStepUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
+    """Update view for WorkflowStep model"""
+
+    model = WorkflowStep
+    form_class = WorkflowStepUpdateForm
+    template_name = WorkflowStepUpdateForm.template_name
+
+    def get_context_data(self, **kwargs):
+        """Custom context"""
+        context = super().get_context_data(**kwargs)
+        context["parameter_form"] = TaskParameterTemplateForm(
+            self.get_object().function, initial=self.object.parameter_template
+        )
+
+        return context
+
+    def get_form_kwargs(self):
+        """Setup kwargs for form instantiation"""
+        kwargs = super().get_form_kwargs()
+        kwargs["environment"] = self.request.session["environment_id"]
+
+        return kwargs
+
+    def post(self, request, workflow_pk, pk):
+        """Handle WorkflowStepForm submission"""
+        # Various parent class calls require the object be set
+        self.object = self.get_object()
+
+        function = Function.objects.get(id=self.request.POST.get("function"))
+        parameter_form = TaskParameterTemplateForm(
+            function=function, data=self.request.POST
+        )
+        step_form = self.get_form()
+
+        if step_form.is_valid() and parameter_form.is_valid():
+            step_form.instance.parameter_template = parameter_form.parameter_template
+            step = step_form.save()
+
+            success_url = reverse("ui:workflow-detail", kwargs={"pk": step.workflow.pk})
+
+            return HttpResponseClientRedirect(success_url)
+        else:
+            context = self.get_context_data()
+            context["parameter_form"] = parameter_form
+
+            return render(self.request, self.template_name, context)
+
+    def test_func(self):
+        """Permission check for view access"""
+        step = self.get_object()
+
+        return self.request.user.has_perm(
+            Permission.WORKFLOW_UPDATE, step.workflow.environment
+        )


### PR DESCRIPTION
Continues #143 

This PR adds the ability to create, delete, and edit workflow steps.  Some related things that happen in this PR:

* Created TaskParameterTemplateForm, a variant of TaskParameterForm that accepts template variables as input in addition to the field type.
* Updated the "function_parameters/" endpoint to take an optional "allow_template_variables" parameter, which decides which variant of the TaskParameterForm gets used.
* Because "function_parameters/" is no longer ScheduledTask specific, it has been relocated to a more appropriate, general location.
* The bit in "function_parameters" that derives the existing parameters so that it can populate the form fields for existing scheduled tasks has been removed.  Instead, the template for updating scheduled tasks just includes the parameter template and no longer does the lazy loading thing.

NOTE: As with much of this Workflow stuff, the UI is purely aiming to be functional.  The goal is to demonstrate the functionality and prove out the general behavior.

## Test Instructions
* Create a workflow and then go to the workflow details page.
* Below the parameters is a new section for steps.
* Play around with adding, editing, and deleting steps.
* The + buttons on a step row inserts a new step below the current one.
* Verify that typed parameters accept only valid input of that type, or a template variable.  For example, an integer parameter should behave as follows:
  * 123 (valid)
  * 12.3 (invalid)
  * somestring (invalid)
  * {{somestring}} (valid)