### PR TITLE
#143 - Reorder workflow steps

### DIFF
--- a/functionary/core/models/workflow_step.py
+++ b/functionary/core/models/workflow_step.py
@@ -97,3 +97,9 @@ class WorkflowStep(models.Model):
     def clean(self):
         if self.workflow.environment != self.function.package.environment:
             raise ValidationError("Function and workflow environments do not match")
+
+    @property
+    def previous(self):
+        """Returns the step preceding this one in the workflow. For the first step in
+        the workflow, returns None."""
+        return self.workflowstep_set.filter(next=self).first()

--- a/functionary/core/utils/workflow.py
+++ b/functionary/core/utils/workflow.py
@@ -91,11 +91,15 @@ def move_step(step: WorkflowStep, next: WorkflowStep | None = None) -> None:
         raise ValueError("Provided step must be a member of the same Workflow")
 
     with transaction.atomic():
-        if old_before_step := WorkflowStep.objects.filter(next=step).first():
+        if old_before_step := WorkflowStep.objects.filter(
+            workflow=step.workflow, next=step
+        ).first():
             old_before_step.next = step.next
             old_before_step.save()
 
-        if new_before_step := WorkflowStep.objects.filter(next=next).first():
+        if new_before_step := WorkflowStep.objects.filter(
+            workflow=step.workflow, next=next
+        ).first():
             new_before_step.next = step
             new_before_step.save()
 

--- a/functionary/ui/templates/partials/workflows/step_list.html
+++ b/functionary/ui/templates/partials/workflows/step_list.html
@@ -18,7 +18,7 @@
                 <tr id="step-{{ step.id }}">
                     <td>
                         {% with previous=step.previous %}
-                            {% if previous.id is not None %}
+                            {% if previous is not None %}
                                 <form id="step-{{ step.id }}-move-up"
                                       method="post"
                                       hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
@@ -33,7 +33,7 @@
                         {% endwith %}
                     </td>
                     <td>
-                        {% if step.next.id is not None %}
+                        {% if step.next is not None %}
                             <form id="step-{{ step.id }}-move-down"
                                   method="post"
                                   hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"

--- a/functionary/ui/templates/partials/workflows/step_list.html
+++ b/functionary/ui/templates/partials/workflows/step_list.html
@@ -5,6 +5,8 @@
     <table class="table is-striped">
         <thead>
             <tr>
+                <th></th>
+                <th></th>
                 <th>Name</th>
                 <th>Function</th>
                 <th>Parameters</th>
@@ -13,7 +15,37 @@
         </thead>
         <tbody id="steps">
             {% for step in workflow.ordered_steps %}
-                <tr>
+                <tr id="step-{{ step.id }}">
+                    <td>
+                        {% with previous=step.previous %}
+                            {% if previous.id is not None %}
+                                <form id="step-{{ step.id }}-move-up"
+                                      method="post"
+                                      hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
+                                      hx-target="#workflow-steps"
+                                      hx-swap="OuterHTML">
+                                    <input type="hidden" name="next" value="{{ previous.id }}"/>
+                                    <button class="button is-small is-white has-text-info fa fa-chevron-up"
+                                            type="submit"
+                                            title="Move Step Up"/>
+                                </form>
+                            {% endif %}
+                        {% endwith %}
+                    </td>
+                    <td>
+                        {% if step.next.id is not None %}
+                            <form id="step-{{ step.id }}-move-down"
+                                  method="post"
+                                  hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
+                                  hx-target="#workflow-steps"
+                                  hx-swap="OuterHTML">
+                                <input type="hidden" name="next" value="{{ step.next.next.id }}"/>
+                                <button class="button is-small is-white has-text-info fa fa-chevron-down"
+                                        type="submit"
+                                        title="Move Step Down"/>
+                            </form>
+                        {% endif %}
+                    </td>
                     <td>{{ step.name }}</td>
                     <td>{{ step.function }}</td>
                     <td class="json-container">{{ step.parameter_template }}</td>

--- a/functionary/ui/tests/views/workflows/steps/test_update.py
+++ b/functionary/ui/tests/views/workflows/steps/test_update.py
@@ -1,0 +1,153 @@
+from uuid import uuid4
+
+import pytest
+from django.urls import reverse
+
+from core.auth import Role
+from core.models import (
+    EnvironmentUserRole,
+    Function,
+    Package,
+    Team,
+    User,
+    Workflow,
+    WorkflowStep,
+)
+
+
+@pytest.fixture
+def environment():
+    team = Team.objects.create(name="team")
+    return team.environments.get()
+
+
+@pytest.fixture
+def package(environment):
+    return Package.objects.create(name="testpackage", environment=environment)
+
+
+@pytest.fixture
+def function(package):
+    function_schema = {
+        "title": "test",
+        "type": "object",
+        "properties": {
+            "prop1": {"type": "integer", "title": "prop1"},
+        },
+    }
+    return Function.objects.create(
+        name="testfunction", package=package, schema=function_schema
+    )
+
+
+@pytest.fixture
+def user_with_access(environment):
+    user_obj = User.objects.create(username="hasaccess")
+
+    EnvironmentUserRole.objects.create(
+        user=user_obj, role=Role.ADMIN.name, environment=environment
+    )
+
+    return user_obj
+
+
+@pytest.fixture
+def user_without_access():
+    return User.objects.create(username="noaccess")
+
+
+@pytest.fixture
+def workflow(environment, user_with_access):
+    return Workflow.objects.create(
+        environment=environment, name="testworkflow", creator=user_with_access
+    )
+
+
+@pytest.fixture
+def step3(workflow, function):
+    return WorkflowStep.objects.create(
+        workflow=workflow,
+        name="step3",
+        function=function,
+        parameter_template='{"prop1": 42}',
+    )
+
+
+@pytest.fixture
+def step2(step3, workflow, function):
+    return WorkflowStep.objects.create(
+        workflow=workflow,
+        name="step2",
+        function=function,
+        parameter_template='{"prop1": 42}',
+        next=step3,
+    )
+
+
+@pytest.fixture
+def step1(step2, workflow, function):
+    return WorkflowStep.objects.create(
+        workflow=workflow,
+        name="step1",
+        function=function,
+        parameter_template='{"prop1": 42}',
+        next=step2,
+    )
+
+
+@pytest.mark.django_db
+def test_move_workflow_step(client, user_with_access, workflow, step1, step2, step3):
+    client.force_login(user_with_access)
+
+    url = reverse(
+        "ui:workflowstep-move", kwargs={"workflow_pk": workflow.pk, "pk": step1.pk}
+    )
+    response = client.post(url, {"next": step3.pk})
+
+    assert response.status_code == 200
+
+    # New order should be step2, step1, step3
+    steps = workflow.ordered_steps
+    assert steps[0] == step2
+    assert steps[1] == step1
+    assert steps[2] == step3
+
+
+@pytest.mark.django_db
+def test_move_workflow_step_returns_400_for_invalid_next_value(
+    client, user_with_access, workflow, step1
+):
+    client.force_login(user_with_access)
+
+    url = reverse(
+        "ui:workflowstep-move", kwargs={"workflow_pk": workflow.pk, "pk": step1.pk}
+    )
+    response = client.post(url, {"next": uuid4()})
+
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_move_workflow_step_returns_403_for_no_access(
+    client, user_without_access, workflow, step1, step3
+):
+    client.force_login(user_without_access)
+
+    url = reverse(
+        "ui:workflowstep-move", kwargs={"workflow_pk": workflow.pk, "pk": step1.pk}
+    )
+    response = client.post(url, {"next": step3.pk})
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_move_workflow_step_returns_404_when_not_found(client, user_with_access):
+    client.force_login(user_with_access)
+
+    url = reverse(
+        "ui:workflowstep-move", kwargs={"workflow_pk": uuid4(), "pk": uuid4()}
+    )
+    response = client.post(url, {"next": uuid4()})
+
+    assert response.status_code == 404

--- a/functionary/ui/urls.py
+++ b/functionary/ui/urls.py
@@ -272,6 +272,11 @@ workflows_urlpatterns = [
         (workflows.WorkflowStepUpdateView.as_view()),
         name="workflowstep-edit",
     ),
+    path(
+        "workflow/<uuid:workflow_pk>/step/<uuid:pk>/move",
+        (workflows.move_workflow_step),
+        name="workflowstep-move",
+    ),
 ]
 
 

--- a/functionary/ui/views/workflows/__init__.py
+++ b/functionary/ui/views/workflows/__init__.py
@@ -8,5 +8,5 @@ from .parameters.edit import (  # noqa
 )
 from .steps.create import WorkflowStepCreateView  # noqa
 from .steps.delete import WorkflowStepDeleteView  # noqa
-from .steps.update import WorkflowStepUpdateView  # noqa
+from .steps.update import WorkflowStepUpdateView, move_workflow_step  # noqa
 from .update import WorkflowUpdateView  # noqa


### PR DESCRIPTION
Continues #143

This PR adds the ability to move workflow steps up or down, one step at a time.  Once again, the UI is entirely function over form, as it just aims to show how the calls to perform the actions should work, with the intent that someone will come back through and make it look pretty later.

## Test Instructions
* Add several steps to a workflow
* In the Steps section of the workflow detail page, click the up and down arrows at the front of the step rows and verify that the steps move as expected.
* Unit tests have been added for the "workflowstep-move" endpoint and all of the responses it is expected to return.