### PR TITLE
#172 - Make user permissions available in the session data

### DIFF
--- a/functionary/ui/templates/core/workflow_list.html
+++ b/functionary/ui/templates/core/workflow_list.html
@@ -2,7 +2,7 @@
 {% block content %}
     <div>
         <div class="level-right">
-            {% if user_has_workflow_create %}
+            {% if request.session.user_can_create_workflow %}
                 <button class="button level-item is-link m-5"
                         hx-target="body"
                         hx-swap="beforeend"

--- a/functionary/ui/templates/forms/environment_selector.html
+++ b/functionary/ui/templates/forms/environment_selector.html
@@ -10,8 +10,8 @@
         <option value="-1">
             Choose
         </option>
-        {% for grp, envs in environments.items %}
-            <optgroup label="{{ grp }}">
+        {% for team, envs in environments.items %}
+            <optgroup label="{{ team }}">
                 {% for env in envs %}
                     <option value="{{ env.id }}"
                             {% if environment_id == env.id|stringformat:'s' %}selected{% endif %}>

--- a/functionary/ui/templates/home.html
+++ b/functionary/ui/templates/home.html
@@ -2,7 +2,7 @@
 {% block content %}
   <div class="content">
     <h1>Hello {{ user.username }}!</h1>
-    {% if not user.environments and not user.is_superuser %}
+    {% if not user.environments %}
       <p>
         You are not a member of any environments. Please contact an administrator to be assigned to an environment to start using Functionary.
       </p>

--- a/functionary/ui/tests/views/test_environment_select.py
+++ b/functionary/ui/tests/views/test_environment_select.py
@@ -1,0 +1,80 @@
+import pytest
+from django.urls import reverse
+
+from core.auth import Role
+from core.models import Environment, EnvironmentUserRole, Package, Team, User
+
+
+@pytest.fixture
+def team():
+    return Team.objects.create(name="team")
+
+
+@pytest.fixture
+def environment(team):
+    return team.environments.get()
+
+
+@pytest.fixture
+def environment_with_no_users():
+    team2 = Team.objects.create(name="team2")
+    return Environment.objects.create(team=team2, name="nousers")
+
+
+@pytest.fixture
+def package(environment):
+    return Package.objects.create(name="testpackage", environment=environment)
+
+
+@pytest.fixture
+def user_with_access(environment):
+    user_obj = User.objects.create(username="hasaccess")
+
+    EnvironmentUserRole.objects.create(
+        user=user_obj, role=Role.READ_ONLY.name, environment=environment
+    )
+
+    return user_obj
+
+
+@pytest.fixture
+def user_without_access():
+    return User.objects.create(username="noaccess")
+
+
+@pytest.mark.django_db
+def test_environment_select_get(
+    client, environment, environment_with_no_users, user_with_access
+):
+    client.force_login(user_with_access)
+
+    url = reverse("ui:set-environment")
+    response = client.get(url)
+    response_body = response.content.decode()
+
+    assert str(environment.id) in response_body
+    assert str(environment_with_no_users.id) not in response_body
+
+
+@pytest.mark.django_db
+def test_environment_select_post(client, environment, user_with_access):
+    client.force_login(user_with_access)
+
+    url = reverse("ui:set-environment")
+    response = client.post(url, {"environment_id": str(environment.id)})
+
+    assert response.status_code == 200
+    assert client.session.get("environment_id") == str(environment.id)
+
+
+@pytest.mark.django_db
+def test_environment_select_post_returns_403_for_no_access(
+    client, environment, user_without_access
+):
+    client.force_login(user_without_access)
+
+    url = reverse("ui:set-environment")
+    response = client.post(url, {"environment_id": str(environment.id)})
+
+    assert response.status_code == 403
+    assert client.session.get("environment_id") != str(environment.id)

--- a/functionary/ui/tests/views/test_utils.py
+++ b/functionary/ui/tests/views/test_utils.py
@@ -1,0 +1,43 @@
+from unittest.mock import Mock
+
+import pytest
+
+from core.auth import Role
+from core.models import EnvironmentUserRole, Team, User
+from ui.views.utils import set_session_environment
+
+
+@pytest.fixture
+def environment():
+    team = Team.objects.create(name="team")
+    return team.environments.get()
+
+
+@pytest.fixture
+def user(environment):
+    user_obj = User.objects.create(username="hasaccess")
+
+    EnvironmentUserRole.objects.create(
+        user=user_obj, role=Role.READ_ONLY.name, environment=environment
+    )
+
+    return user_obj
+
+
+@pytest.mark.django_db
+def test_set_session_environment(environment, user):
+    request = Mock()
+    request.session = {}
+    request.user = user
+
+    set_session_environment(request, environment)
+
+    assert request.session["environment_id"] == str(environment.id)
+
+    # User with READ_ONLY role should have various read permissions
+    assert request.session["user_can_read_function"] is True
+    assert request.session["user_can_read_task"] is True
+
+    # User with READ_ONLY role should *not* have non-read permissions
+    assert request.session["user_can_create_function"] is False
+    assert request.session["user_can_create_task"] is False

--- a/functionary/ui/urls.py
+++ b/functionary/ui/urls.py
@@ -4,6 +4,7 @@ from django.urls import path
 
 from .views import (
     builds,
+    environment_select,
     environments,
     functions,
     home,
@@ -107,6 +108,11 @@ urlpatterns = [
         (variables.VariableView.as_view()),
         name="detail-variable",
     ),
+    path(
+        "environment_select/",
+        (environment_select.EnvironmentSelectView.as_view()),
+        name="set-environment",
+    ),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 htmx_urlpatterns = [
@@ -172,11 +178,6 @@ environment_urlpatterns = [
         "environment_list/",
         (environments.EnvironmentListView.as_view()),
         name="environment-list",
-    ),
-    path(
-        "environment/set_environment",
-        (environments.EnvironmentSelectView.as_view()),
-        name="set-environment",
     ),
     path(
         "environment/<uuid:environment_id>/user_role/create",

--- a/functionary/ui/views/environment_select.py
+++ b/functionary/ui/views/environment_select.py
@@ -1,0 +1,36 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import PermissionDenied
+from django.http import HttpRequest
+from django.shortcuts import get_object_or_404, render
+from django.views.generic import TemplateView
+from django_htmx import http
+
+from core.models import Environment
+from ui.views.utils import set_session_environment
+
+
+class EnvironmentSelectView(LoginRequiredMixin, TemplateView):
+    def post(self, request: HttpRequest):
+        pk = request.POST["environment_id"]
+        environment = get_object_or_404(Environment, pk=pk)
+
+        if not request.user.environments.filter(pk=pk).exists():
+            raise PermissionDenied
+
+        set_session_environment(request, environment)
+
+        return http.HttpResponseClientRedirect("/ui")
+
+    def get(self, request: HttpRequest):
+        envs = self.request.user.environments.select_related("team").order_by(
+            "team__name", "name"
+        )
+
+        environments = {}
+        for env in envs:
+            environments.setdefault(env.team.name, []).append(env)
+
+        self.extra_context = {"environments": environments}
+        context = self.get_context_data()
+
+        return render(request, "forms/environment_selector.html", context)

--- a/functionary/ui/views/environment_select.py
+++ b/functionary/ui/views/environment_select.py
@@ -1,20 +1,20 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.http import HttpRequest
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import render
 from django.views.generic import TemplateView
 from django_htmx import http
 
-from core.models import Environment
 from ui.views.utils import set_session_environment
 
 
 class EnvironmentSelectView(LoginRequiredMixin, TemplateView):
     def post(self, request: HttpRequest):
         pk = request.POST["environment_id"]
-        environment = get_object_or_404(Environment, pk=pk)
 
-        if not request.user.environments.filter(pk=pk).exists():
+        try:
+            environment = request.user.environments.get(pk=pk)
+        except ObjectDoesNotExist:
             raise PermissionDenied
 
         set_session_environment(request, environment)

--- a/functionary/ui/views/environments/__init__.py
+++ b/functionary/ui/views/environments/__init__.py
@@ -3,4 +3,4 @@ from .create import EnvironmentUserRoleCreateView  # noqa
 from .delete import EnvironmentUserRoleDeleteView  # noqa
 from .detail import EnvironmentDetailView  # noqa
 from .list import EnvironmentListView  # noqa
-from .update import EnvironmentSelectView, EnvironmentUserRoleUpdateView  # noqa
+from .update import EnvironmentUserRoleUpdateView  # noqa

--- a/functionary/ui/views/environments/list.py
+++ b/functionary/ui/views/environments/list.py
@@ -9,12 +9,4 @@ class EnvironmentListView(LoginRequiredMixin, ListView):
 
     def get_queryset(self):
         """Sorts based on team name, then env name."""
-        if self.request.user.is_superuser:
-            return (
-                super()
-                .get_queryset()
-                .select_related("team")
-                .order_by("team__name", "name")
-            )
-        else:
-            return self.request.user.environments().select_related("team")
+        return self.request.user.environments.select_related("team")

--- a/functionary/ui/views/environments/update.py
+++ b/functionary/ui/views/environments/update.py
@@ -1,10 +1,7 @@
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.http import HttpRequest, HttpResponse
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
-from django.views.generic.base import TemplateView
 from django.views.generic.edit import UpdateView
-from django_htmx import http
 
 from core.auth import Permission
 from core.models import Environment, EnvironmentUserRole
@@ -37,42 +34,3 @@ class EnvironmentUserRoleUpdateView(
     def test_func(self) -> bool:
         environment = get_object_or_404(Environment, id=self.kwargs["environment_id"])
         return self.request.user.has_perm(Permission.ENVIRONMENT_UPDATE, environment)
-
-
-class EnvironmentSelectView(LoginRequiredMixin, TemplateView):
-    environments = {}
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["environments"] = self.environments
-        return context
-
-    def post(self, request: HttpRequest):
-        pk = request.POST["environment_id"]
-        get_object_or_404(Environment, id=pk)
-
-        request.session["environment_id"] = pk
-        next = request.POST.get("next")
-        if not next:
-            next = "/ui/"
-        return http.trigger_client_event(HttpResponse(""), "reloadData")
-
-    def get(self, request: HttpRequest):
-        if self.request.user.is_superuser:
-            envs = (
-                Environment.objects.select_related("team")
-                .all()
-                .order_by("team__name", "name")
-            )
-        else:
-            envs = self.request.user.environments.select_related("team").order_by(
-                "team__name", "name"
-            )
-
-        self.environments = {}
-        for env in envs:
-            self.environments.setdefault(env.team.name, []).append(env)
-
-        ctx = self.get_context_data()
-        ctx["next"] = request.GET["next"]
-        return render(request, "forms/environment_selector.html", ctx)

--- a/functionary/ui/views/home.py
+++ b/functionary/ui/views/home.py
@@ -1,20 +1,13 @@
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 
-from core.models import Environment
+from ui.views.utils import set_session_environment
 
 
 @login_required
 def home(request):
     if "environment_id" not in request.session:
-        envs = request.user.environments
-        if envs:
-            request.session["environment_id"] = str(
-                envs.order_by("team__name", "name").first().id
-            )
-        elif request.user.is_superuser:
-            request.session["environment_id"] = str(
-                Environment.objects.all().order_by("team__name", "name").first().id
-            )
+        environment = request.user.environments.order_by("team__name", "name").first()
+        set_session_environment(request, environment)
 
     return render(request, "home.html")

--- a/functionary/ui/views/utils.py
+++ b/functionary/ui/views/utils.py
@@ -1,0 +1,53 @@
+from django.http import HttpRequest
+
+from core.auth import Permission
+from core.models import Environment
+
+
+def _set_session_permission(session, permission: str, user_has_permission: bool):
+    """Set the value of the session permission variable"""
+    model, action = permission.split(":")
+
+    session[f"user_can_{action}_{model}"] = user_has_permission
+
+
+def _load_session_permissions(request: HttpRequest, environment: Environment):
+    """Load the user's permissions into the session for ease of access"""
+    user_environment_permissions = request.user.environment_permissions(
+        environment=environment, inherited=True
+    )
+
+    # Start with all permissions set to False to effectively zero out
+    # any permissions granted from the previously selected environment
+    for permission in Permission:
+        _set_session_permission(request.session, permission.value, False)
+
+    for permission in user_environment_permissions:
+        _set_session_permission(request.session, permission, True)
+
+
+def set_session_environment(request: HttpRequest, environment: Environment) -> None:
+    """Set the environment for the session
+
+    For any session there is always a single active environment. This function
+    adds the environment to the session as "environment_id" and the user's permissions
+    for that environment, with entries in the form of "user_can_<action>_<model>". For
+    example:
+
+        * user_can_create_task
+        * user_can_update_workflow
+
+    This makes it possible to do easy checks in a template, for example, by
+    ensuring the request is in the context and then doing a simple check such as:
+
+        {% if request.session.user_can_create_task %}
+
+    Args:
+        request: The HttpRequest containing the session to update
+        environment: The environment to make active for the session
+
+    Returns:
+        None
+    """
+    request.session["environment_id"] = str(environment.id)
+    _load_session_permissions(request, environment)

--- a/functionary/ui/views/workflows/list.py
+++ b/functionary/ui/views/workflows/list.py
@@ -1,5 +1,4 @@
-from core.auth import Permission
-from core.models import Environment, Workflow
+from core.models import Workflow
 from ui.views.view_base import PermissionedEnvironmentListView
 
 PAGINATION_AMOUNT = 10
@@ -12,14 +11,3 @@ class WorkflowListView(PermissionedEnvironmentListView):
     queryset = Workflow.objects.select_related("creator").all()
     order_by_fields = ["name"]
     paginate_by = PAGINATION_AMOUNT
-
-    def get_context_data(self):
-        environment_id = self.request.session.get("environment_id")
-        environment = Environment.objects.get(id=environment_id)
-
-        context = super().get_context_data()
-        context["user_has_workflow_create"] = self.request.user.has_perm(
-            Permission.WORKFLOW_CREATE, environment
-        )
-
-        return context


### PR DESCRIPTION
Closes #172 

The main objective of this PR is to add the user's environment permissions to the session data so that it is always available for use in the context for a template.  With no other setup, you can do something like this in a template:

```
{% if request.session.user_can_create_task %}
```

These `user_can_<action>_<model>` session variables are populated whenever the environment is switched, or via the "home" view that a user is directed to at login.

As part of the changes here, a bunch of other incidental changes were made to the surrounding code.  Namely:

* The `EnvironmentSelectView` was moved into its own file, rather than being lumped in with the views related to the Environment model, since it's really dealing with a different thing.
* The path for the view was changed as well, since the old pathing made it seem like an action against the environment, but that's not really what it is.
* Since it was moving anyway, a bunch of miscellaneous cleanup was done as well.
  * Changing the environment now always just redirects to the home page.  There was an issue before where if you were on a detail page (a specific task for instance) and switched environments, you would end up still on that detail page, even though the object you are looking at is not in the newly active environment.  The least finicky solution to me is to just always start at the landing page when you switch environments.
  * The custom `get_context_data` was removed in favor of using `self.extra_context`.
  * The `is_superuser` check was removed.  More on that below.
* I attempted to remove the `is_superuser` checks scattered throughout the code, in favor of just having the call that returns the user's environments or permission do that check.  This simplifies the logic in the views and templates.

## Testing Instructions
* Unit tests have been added for EnvironmentSelectView as well as the new utility that sets up the session data.
* Verify that the environment select drop down still works as before.
* The workflow list page has a permission check for rendering the create button.  Login as ff-admin and ff-readonly.  The button should appear for the former, but not the latter.