### PR TITLE
#169 - Decreased scheduler wakeup sync delay

### DIFF
--- a/functionary/core/management/commands/run_scheduler.py
+++ b/functionary/core/management/commands/run_scheduler.py
@@ -13,6 +13,9 @@ logger = logging.getLogger("celery.beat")
 logger.setLevel(getattr(logging, LOG_LEVEL))
 
 
+CHECK_FOR_CHANGES_INTERVAL_SECONDS = 5
+
+
 class Command(BaseCommand):
     help = "Run the scheduler"
 
@@ -22,7 +25,7 @@ class Command(BaseCommand):
 
         scheduler = Beat(
             app=app,
-            max_interval=60,
+            max_interval=CHECK_FOR_CHANGES_INTERVAL_SECONDS,
             scheduler=schedulers.DatabaseScheduler,
             loglevel=LOG_LEVEL,
         )


### PR DESCRIPTION
Closes #169 

## Introduced Changes
- Decreased Scheduler's WakeUp Sync Interval
  - This interval is how often the Scheduler queries the DB to figure out which `PeriodicTask`s have been updated. More specifically, which `PeriodicTask`s status' have been updated
  - The caveat with the solution is that if the problem will always exist, its just a matter of how often we want the Scheduler to re-sync with the DB. In this PR, I opted to let it re-sync every 5 seconds. So if I activate, pause, or archive the ScheduledTask when there is less than 5 seconds left before the task is scheduled to run, the task will follow whatever state it was prior to me submitting the updated status.

## Testing
Activate a previously paused or archived ScheduledTask and verify the ScheduledTask runs when expected