### PR TITLE
#183 - Fix package build function deactivation

### DIFF
--- a/functionary/builder/utils.py
+++ b/functionary/builder/utils.py
@@ -319,8 +319,8 @@ def _deactivate_functions(definitions, package: Package):
     for function_def in definitions:
         function_names.append(function_def.get("name"))
 
-    removed_functions = Function.objects.exclude(
-        package=package, name__in=function_names
+    removed_functions = Function.objects.filter(package=package).exclude(
+        name__in=function_names
     )
 
     for function in removed_functions:

--- a/functionary/ui/views/functions.py
+++ b/functionary/ui/views/functions.py
@@ -76,7 +76,6 @@ def execute(request: HttpRequest) -> HttpResponse:
     form = TaskParameterForm(func, data)
 
     if form.is_valid():
-
         # Clean the task fields before saving the Task
         try:
             # Create the new Task, the validated parameters are in form.cleaned_data


### PR DESCRIPTION
Fix to #183 

This fixes a logic bug during the package build that was resulting in all functions for packages other than the one being published getting deactivated.  Now the logic to find which functions to deactivate is properly scoped to the package being published instead.

## Test Instructions
* The unit test for function deactivation has been overhauled to properly capture what we're trying to test: Only functions for the package being published that are not present in the package.yaml get deactivated.  All others remain active.
* To manually test, publish a package, then publish another one.  The functions from the first published package should still be active even after the second one is published.