### PR TITLE
Switch to useradd and don't create log files

### DIFF
--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -15,8 +15,9 @@ ENV PYTHONDONTWRITEBYTECODE 1
 RUN apt-get update && \
     apt-get install -y \
     # python build deps
-    make gcc python3-dev libpq-dev && \
-    adduser $user --uid $uid --disabled-password && \
+    make gcc python3-dev libpq-dev
+
+RUN useradd -l -m -u $uid $user && \
     mkdir -p $install_dir && \
     chown $user:$user -R $install_dir
 


### PR DESCRIPTION
This PR swaps the `adduser` command to `useradd`. This allows for not creating the `lastlog` and `faillog` entries for users that have huge UIDs.