### PR TITLE
#198 - Added util command to not crash while migrations get loaded

### DIFF
--- a/functionary/core/management/commands/run_scheduler.py
+++ b/functionary/core/management/commands/run_scheduler.py
@@ -6,6 +6,7 @@ from django.core.management.base import BaseCommand
 from django_celery_beat import schedulers
 
 from core.celery import app
+from core.management.commands.utils import run
 from core.utils.messaging import initialize_messaging, wait_for_connection
 
 LOG_LEVEL = settings.LOG_LEVEL
@@ -29,4 +30,5 @@ class Command(BaseCommand):
             scheduler=schedulers.DatabaseScheduler,
             loglevel=LOG_LEVEL,
         )
-        scheduler.run()
+
+        run(scheduler.run)

--- a/functionary/core/management/commands/utils.py
+++ b/functionary/core/management/commands/utils.py
@@ -1,0 +1,29 @@
+from time import sleep
+from typing import Callable
+
+from django.db.utils import ProgrammingError
+
+SLEEP_DURATION = 2
+
+
+def run(command: Callable) -> None:
+    """Run the given the command
+
+    The given command will be executed to see if the necessary
+    database migrations have been run. If the migrations have not
+    been run, the command will be re-run after a delay.
+
+    Args:
+        command: The callable command to execute
+
+    Returns:
+        None
+    """
+    is_ready = False
+    while not is_ready:
+        try:
+            command()
+            is_ready = True
+        except ProgrammingError:
+            print("Migrations for the given command have not been run yet.")
+            sleep(SLEEP_DURATION)

--- a/functionary/core/management/commands/utils.py
+++ b/functionary/core/management/commands/utils.py
@@ -1,9 +1,15 @@
+import logging
 from time import sleep
 from typing import Callable
 
-from django.db.utils import ProgrammingError
+from django.conf import settings
+from django.db.utils import DatabaseError
 
-SLEEP_DURATION = 2
+LOG_LEVEL = settings.LOG_LEVEL
+logger = logging.getLogger(__name__)
+logger.setLevel(getattr(logging, LOG_LEVEL))
+
+SLEEP_DURATION = 5
 
 
 def run(command: Callable) -> None:
@@ -24,6 +30,10 @@ def run(command: Callable) -> None:
         try:
             command()
             is_ready = True
-        except ProgrammingError:
-            print("Migrations for the given command have not been run yet.")
+        except DatabaseError:
+            logger.error(
+                f"Database is not ready. "
+                f"Ensure database is available and migrations have been run. "
+                f"Retrying command in {SLEEP_DURATION} seconds."
+            )
             sleep(SLEEP_DURATION)


### PR DESCRIPTION
Closes #198 

## Introduced Changes
- Added a util command for the management commands that will attempt to run the given command
  - The command will be re-run on a delay if the necessary migrations have not been run

## Testing
- Clear your database volume
- Start functionary
  - The scheduler container should not be in a stopped state and claim that the necessary migrations have not been run yet
- Apply the migrations
- The scheduler container will start working as intended once it detects the migrations 