### PR TITLE
#204 - Added S3 error handling to function detail view

### DIFF
--- a/functionary/core/utils/minio.py
+++ b/functionary/core/utils/minio.py
@@ -17,13 +17,7 @@ logger.setLevel(getattr(logging, LOG_LEVEL))
 
 
 class S3ConnectionError(Exception):
-    _err_msg = (
-        "Unable to upload file. Please try again. "
-        "If the problem persists, contact your system administrator."
-    )
-
-    def __init__(self, msg: str = _err_msg, *args, **kwargs):
-        super().__init__(msg, *args, **kwargs)
+    pass
 
 
 class MinioInterface:
@@ -53,15 +47,14 @@ class MinioInterface:
             logger.debug("Successfully connected to S3 provider.")
             self.bucket_name = bucket_name
             self._create_bucket()
-        except MaxRetryError:
-            logger.error(
-                f"Connection to {settings.S3_HOST}:{settings.S3_PORT} could "
-                "not be established."
-            )
-            raise S3ConnectionError()
+        except MaxRetryError as err:
+            msg = f"Connection to S3 provider could not be established. Error: {err}"
+            logger.error(msg)
+            raise S3ConnectionError(msg)
         except S3Error as err:
-            logger.error(f"Error communicating with S3 provider: {err.message}")
-            raise S3ConnectionError()
+            msg = f"Error communicating with S3 provider: {err}"
+            logger.error(msg)
+            raise S3ConnectionError(msg)
 
     def bucket_exists(self) -> bool:
         return self.client.bucket_exists(self.bucket_name)

--- a/functionary/ui/views/function.py
+++ b/functionary/ui/views/function.py
@@ -104,7 +104,7 @@ def execute(request: HttpRequest) -> HttpResponse:
                     code="invalid",
                 ),
             )
-        except S3ConnectionError as err:
+        except S3ConnectionError:
             status_code = 503
             form.add_error(
                 None,

--- a/functionary/ui/views/function.py
+++ b/functionary/ui/views/function.py
@@ -108,7 +108,10 @@ def execute(request: HttpRequest) -> HttpResponse:
             status_code = 503
             form.add_error(
                 None,
-                ValidationError(f"{err}", code="invalid"),
+                (
+                    "Unable to upload file. Please try again. "
+                    "If the problem persists, contact your system administrator."
+                ),
             )
 
     args = {"form": form, "function": func}


### PR DESCRIPTION
Closes #204 

## Introduced Changes
- Throw appropriate exceptions when initializing the MinIO Client
  - `MaxRetryError` when the client is unable to connect to the MinIO instance
  - `S3Error` when client is unable to authenticate the with the MinIO instance
- Since you cannot use the MinIO client without first initializing the client, then this should prevent downstream client exceptions when a connection to MinIO cannot be established

## Testing
- Change the S3 Access Key or Secret key to something other than the Access Key and Secret Key that establishes the MinIO Root User
- Start Functionary
- Use the `Number of Files` function and try to submit a file
  - A non-field error should appear claiming that functionary was unable to authenticate with the S3 provider
- Stop the MinIO container and re-submit the file
  - The page should be in a loading state for about 5 seconds and a non-field error should appear claiming that functionary was unable to connect to the S3 provider 