### PR TITLE
Allow scheduling functions without parameters.

### DIFF
--- a/functionary/core/models/scheduled_task.py
+++ b/functionary/core/models/scheduled_task.py
@@ -49,7 +49,7 @@ class ScheduledTask(ModelSaveHookMixin, models.Model):
         to="Function", on_delete=models.CASCADE, related_name="scheduled_tasks"
     )
     environment = models.ForeignKey(to="Environment", on_delete=models.CASCADE)
-    parameters = models.JSONField(encoder=DjangoJSONEncoder)
+    parameters = models.JSONField(encoder=DjangoJSONEncoder, blank=True)
     status = models.CharField(max_length=16, choices=STATUS_CHOICES, default=PENDING)
     creator = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.PROTECT)
     created_at = models.DateTimeField(auto_now_add=True)
@@ -150,7 +150,8 @@ class ScheduledTask(ModelSaveHookMixin, models.Model):
         """
         if self.periodic_task is None:
             self.periodic_task = PeriodicTask.objects.create(
-                name=self.name,
+                name=self.id,
+                description=self.description or self.name,
                 crontab=crontab_schedule,
                 task="core.utils.tasking.run_scheduled_task",
                 args=f'["{self.id}"]',

--- a/functionary/core/models/scheduled_task.py
+++ b/functionary/core/models/scheduled_task.py
@@ -49,7 +49,7 @@ class ScheduledTask(ModelSaveHookMixin, models.Model):
         to="Function", on_delete=models.CASCADE, related_name="scheduled_tasks"
     )
     environment = models.ForeignKey(to="Environment", on_delete=models.CASCADE)
-    parameters = models.JSONField(encoder=DjangoJSONEncoder, blank=True)
+    parameters = models.JSONField(encoder=DjangoJSONEncoder, blank=True, default=dict)
     status = models.CharField(max_length=16, choices=STATUS_CHOICES, default=PENDING)
     creator = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.PROTECT)
     created_at = models.DateTimeField(auto_now_add=True)
@@ -93,6 +93,8 @@ class ScheduledTask(ModelSaveHookMixin, models.Model):
 
     def _clean_parameters(self):
         """Validate that the parameters conform to the function's schema"""
+        if self.parameters is None:
+            self.parameters = {}
         validate_parameters(self.parameters, self.function)
 
     def clean(self):

--- a/functionary/core/tests/utils/test_parameter.py
+++ b/functionary/core/tests/utils/test_parameter.py
@@ -1,7 +1,7 @@
 import pytest
 from django.core.exceptions import ValidationError
 
-from core.models import Function, FunctionParameter, Package, Task, Team
+from core.models import Function, FunctionParameter, Package, Team
 from core.utils.parameter import PARAMETER_TYPE, validate_parameters
 
 
@@ -30,7 +30,7 @@ def function(package):
 
 
 @pytest.fixture
-def param1(function):
+def json_param(function):
     return FunctionParameter.objects.create(
         name="json_param",
         function=function,
@@ -40,65 +40,50 @@ def param1(function):
 
 
 @pytest.fixture
-def param2(function):
+def date_param(function):
     return FunctionParameter.objects.create(
-        name="dont_hide",
+        name="date_param",
         function=function,
         parameter_type=PARAMETER_TYPE.DATE,
         required=True,
     )
 
 
-@pytest.fixture
-def task(function, environment, admin_user):
-    return Task.objects.create(
-        function=function,
-        environment=environment,
-        parameters={},
-        creator=admin_user,
-    )
-
-
 @pytest.mark.django_db
-@pytest.mark.usefixtures("param1")
-def test_parameters(task):
+def test_parameters(function, json_param):
     """JSON parameters get stringified."""
-    validate_parameters({"json_param": {"hello": 1}}, task.function)
+    validate_parameters({json_param.name: {"hello": 1}}, function)
 
 
 @pytest.mark.django_db
-def test_functions_without_parameters(task):
+def test_functions_without_parameters(function):
     """Check a parameterless function passes."""
-    validate_parameters({}, task.function)
-    validate_parameters({"json_param": {"hello": 1}}, task.function)
+    validate_parameters({}, function)
+    validate_parameters({"json_param": {"hello": 1}}, function)
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("param1", "param2")
-def test_missing_parameter(task):
+def test_missing_parameter(function, json_param, date_param):
     """Check for missing param2"""
-    with pytest.raises(ValidationError, match=r".*dont_hide.*"):
-        validate_parameters({"json_param": {"hello": 1}}, task.function)
+    with pytest.raises(ValidationError, match=r".*date_param.*"):
+        validate_parameters({json_param.name: {"hello": 1}}, function)
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("param1")
-def test_incorrect_parameters(task):
+def test_incorrect_parameters(function, json_param):
     """Check that incorrect parameters don't work."""
-    with pytest.raises(ValidationError, match=r".*json_param.*is a required.*"):
-        validate_parameters({}, task.function)
+    with pytest.raises(ValidationError, match=r".*json_param.*required.*"):
+        validate_parameters({}, function)
 
-    with pytest.raises(ValidationError, match=r".*json_param.*is a required.*"):
-        validate_parameters({"true": False}, task.function)
+    with pytest.raises(ValidationError, match=r".*json_param.*required.*"):
+        validate_parameters({"true": False}, function)
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("param1", "param2")
-def test_incorrect_parameters2(task):
-    """Check that incorrect parameters don't work."""
-    with pytest.raises(ValidationError, match=r".*dont_hide.*"):
-        validate_parameters({"json_param": 1, "dont_hide": False}, task.function)
+def test_incorrect_parameter_type(function, json_param, date_param):
+    """Check that parameters with an incorrect type don't work."""
+    with pytest.raises(ValidationError, match=r".*date_param.*"):
+        validate_parameters({json_param.name: 1, date_param.name: False}, function)
 
-    # The following should fail but doesn't
-    # with pytest.raises(ValidationError, match=r".*dont_hide.*"):
-    #     validate_parameters({"json_param": 1, "dont_hide": "False"}, task.function)
+    with pytest.raises(ValidationError, match=r".*date_param.*"):
+        validate_parameters({json_param.name: 1, date_param.name: "False"}, function)

--- a/functionary/core/tests/utils/test_parameter.py
+++ b/functionary/core/tests/utils/test_parameter.py
@@ -1,0 +1,95 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from core.models import Function, FunctionParameter, Package, Task, Team
+from core.utils.parameter import PARAMETER_TYPE, validate_parameters
+
+
+@pytest.fixture
+def team():
+    return Team.objects.create(name="team")
+
+
+@pytest.fixture
+def environment(team):
+    return team.environments.get()
+
+
+@pytest.fixture
+def package(environment):
+    return Package.objects.create(name="testpackage", environment=environment)
+
+
+@pytest.fixture
+def function(package):
+    return Function.objects.create(
+        name="testfunction",
+        package=package,
+        environment=package.environment,
+        # parameters=["env_var1", "dont_hide", "team_var1"],
+    )
+
+
+@pytest.fixture
+def param1(function):
+    return FunctionParameter.objects.create(
+        name="json_param",
+        function=function,
+        parameter_type=PARAMETER_TYPE.JSON,
+        required=True,
+    )
+
+
+@pytest.fixture
+def param2(function):
+    return FunctionParameter.objects.create(
+        name="dont_hide",
+        function=function,
+        parameter_type=PARAMETER_TYPE.DATE,
+        required=True,
+    )
+
+
+@pytest.fixture
+def task(function, environment, admin_user):
+    return Task.objects.create(
+        function=function,
+        environment=environment,
+        parameters={},
+        creator=admin_user,
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("param1")
+def test_parameters(task):
+    """JSON parameters get stringified."""
+    validate_parameters({"json_param": {"hello": 1}}, task.function)
+
+
+@pytest.mark.django_db
+def test_functions_without_parameters(task):
+    """Check a parameterless function passes."""
+    validate_parameters({}, task.function)
+    validate_parameters({"json_param": {"hello": 1}}, task.function)
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("param1", "param2")
+def test_missing_parameter(task):
+    """Check for missing param2"""
+    with pytest.raises(ValidationError):
+        validate_parameters({"json_param": 1, "dont_hide": False}, task.function)
+    with pytest.raises(ValidationError, match=r".*dont_hide.*"):
+        validate_parameters({"json_param": {"hello": 1}}, task.function)
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("param1")
+def test_incorrect_parameters(task):
+    """Check that incorrect parameters don't work."""
+    with pytest.raises(ValidationError, match=r".*json_param.*missing.*"):
+        validate_parameters({}, task.function)
+
+    with pytest.raises(ValidationError, match=r".*json_param.*missing.*"):
+        validate_parameters({"true": False}, task.function)

--- a/functionary/core/tests/utils/test_parameter.py
+++ b/functionary/core/tests/utils/test_parameter.py
@@ -26,7 +26,6 @@ def function(package):
         name="testfunction",
         package=package,
         environment=package.environment,
-        # parameters=["env_var1", "dont_hide", "team_var1"],
     )
 
 
@@ -78,8 +77,6 @@ def test_functions_without_parameters(task):
 @pytest.mark.usefixtures("param1", "param2")
 def test_missing_parameter(task):
     """Check for missing param2"""
-    with pytest.raises(ValidationError):
-        validate_parameters({"json_param": 1, "dont_hide": False}, task.function)
     with pytest.raises(ValidationError, match=r".*dont_hide.*"):
         validate_parameters({"json_param": {"hello": 1}}, task.function)
 
@@ -88,8 +85,20 @@ def test_missing_parameter(task):
 @pytest.mark.usefixtures("param1")
 def test_incorrect_parameters(task):
     """Check that incorrect parameters don't work."""
-    with pytest.raises(ValidationError, match=r".*json_param.*missing.*"):
+    with pytest.raises(ValidationError, match=r".*json_param.*is a required.*"):
         validate_parameters({}, task.function)
 
-    with pytest.raises(ValidationError, match=r".*json_param.*missing.*"):
+    with pytest.raises(ValidationError, match=r".*json_param.*is a required.*"):
         validate_parameters({"true": False}, task.function)
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("param1", "param2")
+def test_incorrect_parameters2(task):
+    """Check that incorrect parameters don't work."""
+    with pytest.raises(ValidationError, match=r".*dont_hide.*"):
+        validate_parameters({"json_param": 1, "dont_hide": False}, task.function)
+
+    # The following should fail but doesn't
+    # with pytest.raises(ValidationError, match=r".*dont_hide.*"):
+    #     validate_parameters({"json_param": 1, "dont_hide": "False"}, task.function)

--- a/functionary/core/utils/parameter.py
+++ b/functionary/core/utils/parameter.py
@@ -96,6 +96,7 @@ def validate_parameters(parameters: dict, instance: Union["Function", "Workflow"
     """
     try:
         pydantic_model = _get_pydantic_model(instance)
+        # KeyError will get thrown if one or more parameters are invalid
         _ = pydantic_model(**_serialize_json_parameters(parameters, instance))
-    except (ValidationError, json.JSONDecodeError) as exc:
+    except (KeyError, ValidationError, json.JSONDecodeError) as exc:
         raise DjangoValidationError(exc)

--- a/functionary/core/utils/parameter.py
+++ b/functionary/core/utils/parameter.py
@@ -4,7 +4,9 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Type, TypeVar, Union
 
 from django.core.exceptions import ValidationError as DjangoValidationError
-from pydantic import BaseModel, Field, FileUrl, Json, ValidationError, create_model
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+from pydantic import BaseModel, Field, FileUrl, Json, create_model
 
 if TYPE_CHECKING:
     from core.models import Function, Workflow
@@ -98,6 +100,8 @@ def validate_parameters(parameters: dict, instance: Union["Function", "Workflow"
     """
     try:
         pydantic_model = _get_pydantic_model(instance)
-        _ = pydantic_model(**_serialize_json_parameters(parameters, instance))
+        validate(
+            _serialize_json_parameters(parameters, instance), pydantic_model.schema()
+        )
     except (ValidationError, json.JSONDecodeError) as exc:
         raise DjangoValidationError(exc)

--- a/functionary/core/utils/parameter.py
+++ b/functionary/core/utils/parameter.py
@@ -63,7 +63,9 @@ def _serialize_json_parameters(
     """Serializes json type parameters for use in validation"""
     parameters_copy = deepcopy(parameters)
 
-    for parameter_obj in instance.parameters.filter(parameter_type=PARAMETER_TYPE.JSON):
+    for parameter_obj in instance.parameters.filter(
+        name__in=parameters.keys(), parameter_type=PARAMETER_TYPE.JSON
+    ):
         name = parameter_obj.name
         parameters_copy[name] = json.dumps(parameters_copy[name])
 
@@ -96,7 +98,6 @@ def validate_parameters(parameters: dict, instance: Union["Function", "Workflow"
     """
     try:
         pydantic_model = _get_pydantic_model(instance)
-        # KeyError will get thrown if one or more parameters are invalid
         _ = pydantic_model(**_serialize_json_parameters(parameters, instance))
-    except (KeyError, ValidationError, json.JSONDecodeError) as exc:
+    except (ValidationError, json.JSONDecodeError) as exc:
         raise DjangoValidationError(exc)

--- a/functionary/ui/forms/scheduled_task.py
+++ b/functionary/ui/forms/scheduled_task.py
@@ -1,4 +1,6 @@
-from django.forms import CharField, ModelChoiceField, ModelForm
+from django.core import validators
+from django.core.serializers.json import DjangoJSONEncoder
+from django.forms import CharField, JSONField, ModelChoiceField, ModelForm
 from django.urls import reverse
 from django_celery_beat.validators import (
     day_of_month_validator,
@@ -11,7 +13,26 @@ from django_celery_beat.validators import (
 from core.models import Environment, Function, ScheduledTask
 
 
+class NotNoneJSONField(JSONField):
+    """This class creates a JSONField that overrides the return value when the field
+    holds a normally empty value. This is to ensure that validation still runs."""
+
+    def __init__(self, default_value=dict, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.default_value = default_value()
+        self.empty_values = [
+            v for v in validators.EMPTY_VALUES if v != self.default_value
+        ]
+
+    def to_python(self, value):
+        """This override returns a default_value if the field evaluates
+        the value to empty."""
+        python_value = super().to_python(value)
+        return python_value if python_value is not None else self.default_value
+
+
 class ScheduledTaskForm(ModelForm):
+    existing_errors = None
     scheduled_minute = CharField(
         max_length=60 * 4, label="Minute", initial="*", validators=[minute_validator]
     )
@@ -37,6 +58,7 @@ class ScheduledTaskForm(ModelForm):
         validators=[month_of_year_validator],
     )
     function = ModelChoiceField(queryset=Function.objects.all(), required=True)
+    parameters = NotNoneJSONField(encoder=DjangoJSONEncoder)
 
     class Meta:
         model = ScheduledTask
@@ -52,11 +74,20 @@ class ScheduledTaskForm(ModelForm):
             "parameters",
         ]
 
-    def __init__(self, environment: Environment = None, *args, **kwargs):
+    def __init__(
+        self,
+        environment: Environment = None,
+        existing_errors=None,
+        *args,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self._setup_field_choices(kwargs.get("instance") is not None)
         self._update_function_queryset(environment)
         self._setup_field_classes()
+        self.existing_errors = (
+            [f"'{k}'" for k in existing_errors.keys()] if existing_errors else {}
+        )
 
     def _update_function_queryset(self, environment: Environment):
         if environment:
@@ -129,3 +160,17 @@ class ScheduledTaskForm(ModelForm):
                     "hx-target": f"#{field_id}_errors",
                 }
             )
+
+    def is_valid(self):
+        return not self.existing_errors and super().is_valid()
+
+    def add_error(self, field, error):
+        # If field is defined, it's for the form. If it's not, it's probably
+        # from the parameters. This error is already shown on the field, so
+        # don't show it again for the whole form.
+        if not field:
+            for _, val in error:
+                found = [v for v in val if v in self.existing_errors]
+                if found:
+                    return
+        super().add_error(field, error)

--- a/functionary/ui/templates/core/scheduledtask_detail.html
+++ b/functionary/ui/templates/core/scheduledtask_detail.html
@@ -1,97 +1,95 @@
 {% extends "base.html" %}
 {% load static %}
 {% block content %}
-
-
-<nav class="breadcrumb has-arrow-separator mt-3" aria-label="breadcrumbs">
-    <ul>
-        <li>
-            <a href="{% url 'ui:scheduledtask-list' %}">Schedules List</a>
-        </li>
-        <li class="is-active">
-            <a href="#">
-                {{ scheduledtask.name }}
-            </a>
-        </li>
-    </ul>
-</nav>
-<div class="block mt-4">
-    <h1 class="title is-1">
-        <p>
-            <i class="fa fa-clock"></i>
-            <span>
-                {{ scheduledtask.name }}
-            </span>
-        </p>
-    </h1>
-</div>
-<div class="block has-addons">
-    <div class="block">
-        <label class="label" for="users">
-            <i class="fa fa-user"></i>&nbsp;Creator:
-        </label>
-        <p class="ml-4">
-            {{ scheduledtask.creator.first_name }} {{ scheduledtask.creator.last_name }} <span class="has-text-grey-light">({{ scheduledtask.creator.username }})</span>
-            at {{ scheduledtask.created_at }}
-        </p>
+    <nav class="breadcrumb has-arrow-separator mt-3" aria-label="breadcrumbs">
+        <ul>
+            <li>
+                <a href="{% url 'ui:scheduledtask-list' %}">Schedules List</a>
+            </li>
+            <li class="is-active">
+                <a href="#">{{ scheduledtask.name }}</a>
+            </li>
+        </ul>
+    </nav>
+    <div class="block mt-4">
+        <h1 class="title is-1">
+            <p>
+                <i class="fa fa-clock"></i>
+                <span>{{ scheduledtask.name }}</span>
+                <a href="{% url 'ui:scheduledtask-update' scheduledtask.id %}">
+                    <button class="button is-small has-text-link is-white singletonActive">
+                        <span class="fa fa-pencil-alt"></span>
+                    </button>
+                </a>
+            </p>
+        </h1>
     </div>
-    <div class="field">
-        <label class="label" for="status">
-            <i class="fa fa-heart-pulse"></i>&nbsp;Status:
-        </label>
-        <span class="ml-4">{{ scheduledtask.status }}</span>
-    </div>
-    {% if scheduledtask.description %}
+    <div class="block has-addons">
+        <div class="block">
+            <label class="label" for="users">
+                <i class="fa fa-user"></i>&nbsp;Creator:
+            </label>
+            <p class="ml-4">
+                {{ scheduledtask.creator.first_name }} {{ scheduledtask.creator.last_name }} <span class="has-text-grey-light">({{ scheduledtask.creator.username }})</span>
+                at {{ scheduledtask.created_at }}
+            </p>
+        </div>
         <div class="field">
-            <label class="label" for="desc">Description:</label>
-            <div class="ml-4">
-                <span id="desc">{{ scheduledtask.description }}</span>
+            <label class="label" for="status">
+                <i class="fa fa-heart-pulse"></i>&nbsp;Status:
+            </label>
+            <span class="ml-4">{{ scheduledtask.status }}</span>
+        </div>
+        {% if scheduledtask.description %}
+            <div class="field">
+                <label class="label" for="desc">Description:</label>
+                <div class="ml-4">
+                    <span id="desc">{{ scheduledtask.description }}</span>
+                </div>
+            </div>
+        {% endif %}
+        <div class="field">
+            <label class="label" for="function">
+                <i class="fa fa-cube"></i>&nbsp;Function:
+            </label>
+            <a href="{% url 'ui:function-detail' scheduledtask.function.id %}"><span class="ml-4">{{ scheduledtask.function.render_name }}</span></a>
+        </div>
+        <div class="field">
+            <label class="label" for="crontab">
+                <i class="fa fa-calendar"></i>&nbsp;Crontab:
+            </label>
+            <span class="ml-4">{{ scheduledtask.periodic_task.crontab }}</span>
+        </div>
+        <div class="field">
+            <label class="label" for="params">
+                <i class="fa fa-list"></i>&nbsp;Parameters:
+            </label>
+            <pre class="block ml-4 mr-4" id="params">{{ scheduledtask.parameters | pprint }}</pre>
+        </div>
+        <div class="field">
+            <label class="label" for="params">
+                <i class="fa fa-clock-rotate-left"></i>&nbsp;Recent History:
+            </label>
+            <div class="table-container ml-4">
+                <table class="table is-hoverable">
+                    <thead>
+                        <tr>
+                            <th>Ran at</th>
+                            <th>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for task in history %}
+                            <tr>
+                                <td>
+                                    <a href="{% url 'ui:task-detail' task.id %}">{{ task.created_at }}</a>
+                                </td>
+                                <td>{{ task.status }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
         </div>
-    {% endif %}
-    <div class="field">
-        <label class="label" for="function">
-            <i class="fa fa-cube"></i>&nbsp;Function:
-        </label>
-        <a href="{% url 'ui:function-detail' scheduledtask.function.id %}"><span class="ml-4">{{ scheduledtask.function.render_name }}</span></a>
     </div>
-    <div class="field">
-        <label class="label" for="crontab">
-            <i class="fa fa-calendar"></i>&nbsp;Crontab:
-        </label>
-        <span class="ml-4">{{ scheduledtask.periodic_task.crontab }}</span>
-    </div>
-    <div class="field">
-        <label class="label" for="params">
-            <i class="fa fa-list"></i>&nbsp;Parameters:
-        </label>
-        <pre class="block ml-4 mr-4" id="params">{{ scheduledtask.parameters | pprint }}</pre>
-    </div>
-
-   <div class="field">
-        <label class="label" for="params">
-            <i class="fa fa-clock-rotate-left"></i>&nbsp;Recent History:
-        </label>
-        <div class="table-container ml-4">
-            <table class="table is-hoverable">
-                <thead>
-                    <tr>
-                        <th>Ran at</th>
-                        <th>Status</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for task in history %}
-                    <tr>
-                        <td>
-                            <a href="{% url 'ui:task-detail' task.id %}">{{ task.created_at }}</a>
-                        </td>
-                        <td>{{ task.status }}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-   </div> 
-</div>
 {% endblock content %}

--- a/functionary/ui/templates/forms/scheduled_task/scheduled_task_edit.html
+++ b/functionary/ui/templates/forms/scheduled_task/scheduled_task_edit.html
@@ -2,261 +2,232 @@
 {% load widget_tweaks %}
 {% load static %}
 {% block content %}
-<div class="block">
-    {% if form %}
-        
-        {% if update %}
-            <form method="post" action="{% url 'ui:scheduledtask-update' scheduledtask.id %}" enctype="multipart/form-data">
-        {% else %}
-            <form method="post" action="{% url 'ui:scheduledtask-create' %}" enctype="multipart/form-data">
-        {% endif %}
-            
-        {% csrf_token %}
-            
-            <!-- Non-Field Errors display -->
-            <div class="columns is-centered">
-                <div class="column has-text-centered is-half">
-                    {% if form.non_field_errors %}
-                    <div class="notification is-warning has-text-black">
-                        <button class="delete" onclick="return this.parentNode.remove();"></button>
-                        Non-Field Errors:
-                        {{ form.non_field_errors }}
-                    </div>
+    <div class="block">
+        {% if form %}
+            {% if update %}
+                <form method="post"
+                      action="{% url 'ui:scheduledtask-update' scheduledtask.id %}"
+                      enctype="multipart/form-data">
+                {% else %}
+                    <form method="post"
+                          action="{% url 'ui:scheduledtask-create' %}"
+                          enctype="multipart/form-data">
                     {% endif %}
-                </div>
-            </div>
-
-            <!-- Name row/field -->
-            <div class="box">
-
-                <div class="field">
-                    <div class="columns is-8">
-                        <div class="column is-one-third">
-                            <label for="{{ form.name.id_for_label }}">
-                                <b class="title is-size-4">{{ form.name.label }}</b> 
-                                <span class="is-small has-text-grey-light">{{ form.name.label_suffix }}</span>
-                                &nbsp;&nbsp;&nbsp;{{ form.name.help_text }}
-                            </label>
-                            <div class="column is-one-half p-0 is-italic subtitle is-size-6">
-                                <p>Give a descriptive name for your scheduled task.</p>
-                            </div>
-                            <div class="errorlist">
-                                {{ form.name.errors }}
-                            </div>
-                        </div>
-                        <div class="column">
-                            <div class="control">
-                                {{ form.name }}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <hr/>
-
-                {% if update %}
-                <div class="field">
-                    <div class="columns is-8">
-                        <div class="column is-one-third">
-                            <label for="{{ form.status.id_for_label }}">
-                                <b class="title is-size-4">{{ form.status.label }}</b> 
-                                <span class="is-small has-text-grey-light">{{ form.status.label_suffix }}</span>
-                                &nbsp;&nbsp;&nbsp;{{ form.status.help_text }}
-                            </label>
-                            <div class="column is-one-half p-0 is-italic subtitle is-size-6">
-                                <p>Update the status of your scheduled task.</p>
-                            </div>
-                            <div class="errorlist">
-                                {{ form.status.errors }}
-                            </div>
-                        </div>
-                        <div class="column is-one-third">
-                            <div class="control">
-                                {{ form.status }}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                
-                <hr/>
-                {% endif %}
-
-                <!-- Description row/field -->
-                <div class="field">
-                    <div class="columns is-8">
-                        <div class="column is-one-third">
-                            <label for="{{ form.description.id_for_label }}">
-                                <b {% if form.description.errors %}class="errors"{% endif %} class="title is-size-4">{{ form.description.label }}</b> 
-                                <span class="is-small has-text-grey-light">{{ form.description.label_suffix }}</span>
-                                &nbsp;&nbsp;&nbsp;{{ form.description.help_text }}
-                            </label>
-                            <div class="column is-one-half p-0 is-italic subtitle is-size-6">
-                                <p>Give a description for your scheduled task.</p>
-                            </div>
-                            <div class="errorlist">
-                                {{ form.description.errors }}
-                            </div>
-                        </div>
-                        <div class="column">
-                            <div class="control">
-                                {{ form.description }}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <hr/>
-
-                <!-- Function row/field -->
-                <div class="field">
-                    <div class="columns">
-                        <div class="column is-one-third">
-                            <label for="{{ form.function.id_for_label }}">
-                                <b class="title is-size-4">{{ form.function.label }}</b> 
-                                <span class="is-small has-text-grey-light">{{ form.function.label_suffix }}</span>
-                                &nbsp;&nbsp;&nbsp;{{ form.function.help_text }}
-                            </label>
-                            <div class="column p-0 is-italic subtitle is-size-6">
-                                <p>Select which function you want to schedule.</p>
-                            </div>
-                            <div class="errorlist">
-                                {{ form.function.errors }}
-                            </div>
-                        </div>
-                        <div class="column is-one-third">
-                            {% if update %}
-                            <div class="control">
-                                {% render_field form.function disabled=True %}
-                            </div>
-                            {% else %}
-                            <div class="control">
-                                {{ form.function }}
-                            </div>
+                    {% csrf_token %}
+                    <!-- Non-Field Errors display -->
+                    <div class="columns is-centered">
+                        <div class="column has-text-centered is-half">
+                            {% if form.non_field_errors %}
+                                <div class="notification is-warning has-text-black">
+                                    <button class="delete" onclick="return this.parentNode.remove();"></button>
+                                    Non-Field Errors:
+                                    {{ form.non_field_errors }}
+                                </div>
                             {% endif %}
                         </div>
                     </div>
-                </div>
-
-                <hr/>
-
-                <!-- Crontab row/field -->
-                <div class="field">
-                    <div class="columns">
-                        <div class="column is-one-third">
-                            <label>
-                                <b class="title is-size-4">Crontab Schedule</b> 
-                            </label>
-                            <div class="column p-0 is-italic subtitle is-size-6">
-                                <p>Setup the Crontab-style schedule.</p>
-                            </div>
-                        </div>
-
-                        <div class="columns is-multiline">
-                            <div class="column is-one-third">
-                                <div class="box">
-                                    <label for="{{ form.scheduled_minute.id_for_label }}">
-                                        <span>{{ form.scheduled_minute.label }}</span>
+                    <!-- Name row/field -->
+                    <div class="box">
+                        <div class="field">
+                            <div class="columns is-8">
+                                <div class="column is-one-third">
+                                    <label for="{{ form.name.id_for_label }}">
+                                        <b class="title is-size-4">{{ form.name.label }}</b>
+                                        <span class="is-small has-text-grey-light">{{ form.name.label_suffix }}</span>
+                                        &nbsp;&nbsp;&nbsp;{{ form.name.help_text }}
                                     </label>
-                                    <div class="control">
-                                        {{ form.scheduled_minute }}
-                                        {{ form.scheduled_minute.errors }}
+                                    <div class="column is-one-half p-0 is-italic subtitle is-size-6">
+                                        <p>Give a descriptive name for your scheduled task.</p>
                                     </div>
-                                    <div id="{{ form.scheduled_minute.id_for_label }}_errors">
-                                    </div>
+                                    <div class="errorlist">{{ form.name.errors }}</div>
                                 </div>
-                            </div>
-                            <div class="column is-one-third">
-                                <div class="box">
-                                    <label for="{{ form.scheduled_hour.id_for_label }}">
-                                        <span>{{ form.scheduled_hour.label }}</span>
-                                    </label>
-                                    <div class="control">
-                                        {{ form.scheduled_hour }}
-                                        {{ form.scheduled_hour.errors }}
-                                    </div>
-                                    <div id="{{ form.scheduled_hour.id_for_label }}_errors">
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="column is-one-third">
-                                <div class="box">
-                                    <label for="{{ form.scheduled_day_of_week.id_for_label }}">
-                                        <span>{{ form.scheduled_day_of_week.label }}</span>
-                                    </label>
-                                    <div class="control">
-                                        {{ form.scheduled_day_of_week }}
-                                        {{ form.scheduled_day_of_week.errors }}
-                                    </div>
-                                    <div id="{{ form.scheduled_day_of_week.id_for_label }}_errors">
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="column is-one-third">
-                                <div class="box">
-                                    <label for="{{ form.scheduled_day_of_month.id_for_label }}">
-                                        <span>{{ form.scheduled_day_of_month.label }}</span>
-                                    </label>
-                                    <div class="control">
-                                        {{ form.scheduled_day_of_month }}
-                                        {{ form.scheduled_day_of_month.errors }}
-                                    </div>
-                                    <div id="{{ form.scheduled_day_of_month.id_for_label }}_errors">
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="column is-one-third">
-                                <div class="box">
-                                    <label for="{{ form.scheduled_month_of_year.id_for_label }}">
-                                        <span>{{ form.scheduled_month_of_year.label }}</span>
-                                    </label>
-                                    <div class="control">
-                                        {{ form.scheduled_month_of_year }}
-                                        {{ form.scheduled_month_of_year.errors }}
-                                    </div>
-                                    <div id="{{ form.scheduled_month_of_year.id_for_label }}_errors">
-                                    </div>
+                                <div class="column">
+                                    <div class="control">{{ form.name }}</div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </div>
-
-                <hr/>
-
-                <!-- Load function parameters -->
-                <div class="field">
-                    <div class="columns">
-                        <div class="column is-one-third">
-                            <label for="{{ form.parameters.id_for_label }}">
-                                <b class="title is-size-4">{{ form.parameters.label }}</b> 
-                                <span class="is-small has-text-grey-light">{{ form.parameters.label_suffix }}</span>
-                                &nbsp;&nbsp;&nbsp;{{ form.parameters.help_text }}
-                            </label>
-                            <div class="column p-0 is-italic subtitle is-size-6">
-                                Please enter the parameters for the function.
+                        <hr/>
+                        {% if update %}
+                            <div class="field">
+                                <div class="columns is-8">
+                                    <div class="column is-one-third">
+                                        <label for="{{ form.status.id_for_label }}">
+                                            <b class="title is-size-4">{{ form.status.label }}</b>
+                                            <span class="is-small has-text-grey-light">{{ form.status.label_suffix }}</span>
+                                            &nbsp;&nbsp;&nbsp;{{ form.status.help_text }}
+                                        </label>
+                                        <div class="column is-one-half p-0 is-italic subtitle is-size-6">
+                                            <p>Update the status of your scheduled task.</p>
+                                        </div>
+                                        <div class="errorlist">{{ form.status.errors }}</div>
+                                    </div>
+                                    <div class="column is-one-third">
+                                        <div class="control">{{ form.status }}</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <hr/>
+                        {% endif %}
+                        <!-- Description row/field -->
+                        <div class="field">
+                            <div class="columns is-8">
+                                <div class="column is-one-third">
+                                    <label for="{{ form.description.id_for_label }}">
+                                        <b {% if form.description.errors %}class="errors"{% endif %}
+                                           class="title is-size-4">{{ form.description.label }}</b>
+                                        <span class="is-small has-text-grey-light">{{ form.description.label_suffix }}</span>
+                                        &nbsp;&nbsp;&nbsp;{{ form.description.help_text }}
+                                    </label>
+                                    <div class="column is-one-half p-0 is-italic subtitle is-size-6">
+                                        <p>Give a description for your scheduled task.</p>
+                                    </div>
+                                    <div class="errorlist">{{ form.description.errors }}</div>
+                                </div>
+                                <div class="column">
+                                    <div class="control">{{ form.description }}</div>
+                                </div>
                             </div>
                         </div>
-
-                        {% comment %} Render function param form if available. Else, lazy load. {% endcomment %}
-                        {% if task_parameter_form %}
-                            <div class="column" id="function-parameters">
-                                {{ task_parameter_form }}
+                        <hr/>
+                        <!-- Function row/field -->
+                        <div class="field">
+                            <div class="columns">
+                                <div class="column is-one-third">
+                                    <label for="{{ form.function.id_for_label }}">
+                                        <b class="title is-size-4">{{ form.function.label }}</b>
+                                        <span class="is-small has-text-grey-light">{{ form.function.label_suffix }}</span>
+                                        &nbsp;&nbsp;&nbsp;{{ form.function.help_text }}
+                                    </label>
+                                    <div class="column p-0 is-italic subtitle is-size-6">
+                                        <p>Select which function you want to schedule.</p>
+                                    </div>
+                                    <div class="errorlist">{{ form.function.errors }}</div>
+                                </div>
+                                <div class="column is-one-third">
+                                    {% if update %}
+                                        <div class="control">{% render_field form.function disabled=True %}</div>
+                                    {% else %}
+                                        <div class="control">{{ form.function }}</div>
+                                    {% endif %}
+                                </div>
                             </div>
+                        </div>
+                        <hr/>
+                        <!-- Crontab row/field -->
+                        <div class="field">
+                            <div class="columns">
+                                <div class="column is-one-third">
+                                    <label>
+                                        <b class="title is-size-4">Crontab Schedule</b>
+                                    </label>
+                                    <div class="column p-0 is-italic subtitle is-size-6">
+                                        <p>Setup the Crontab-style schedule.</p>
+                                    </div>
+                                </div>
+                                <div class="columns is-multiline">
+                                    <div class="column is-one-third">
+                                        <div class="box">
+                                            <label for="{{ form.scheduled_minute.id_for_label }}">
+                                                <span>{{ form.scheduled_minute.label }}</span>
+                                            </label>
+                                            <div class="control">
+                                                {{ form.scheduled_minute }}
+                                                {{ form.scheduled_minute.errors }}
+                                            </div>
+                                            <div id="{{ form.scheduled_minute.id_for_label }}_errors"></div>
+                                        </div>
+                                    </div>
+                                    <div class="column is-one-third">
+                                        <div class="box">
+                                            <label for="{{ form.scheduled_hour.id_for_label }}">
+                                                <span>{{ form.scheduled_hour.label }}</span>
+                                            </label>
+                                            <div class="control">
+                                                {{ form.scheduled_hour }}
+                                                {{ form.scheduled_hour.errors }}
+                                            </div>
+                                            <div id="{{ form.scheduled_hour.id_for_label }}_errors"></div>
+                                        </div>
+                                    </div>
+                                    <div class="column is-one-third">
+                                        <div class="box">
+                                            <label for="{{ form.scheduled_day_of_week.id_for_label }}">
+                                                <span>{{ form.scheduled_day_of_week.label }}</span>
+                                            </label>
+                                            <div class="control">
+                                                {{ form.scheduled_day_of_week }}
+                                                {{ form.scheduled_day_of_week.errors }}
+                                            </div>
+                                            <div id="{{ form.scheduled_day_of_week.id_for_label }}_errors"></div>
+                                        </div>
+                                    </div>
+                                    <div class="column is-one-third">
+                                        <div class="box">
+                                            <label for="{{ form.scheduled_day_of_month.id_for_label }}">
+                                                <span>{{ form.scheduled_day_of_month.label }}</span>
+                                            </label>
+                                            <div class="control">
+                                                {{ form.scheduled_day_of_month }}
+                                                {{ form.scheduled_day_of_month.errors }}
+                                            </div>
+                                            <div id="{{ form.scheduled_day_of_month.id_for_label }}_errors">
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="column is-one-third">
+                                        <div class="box">
+                                            <label for="{{ form.scheduled_month_of_year.id_for_label }}">
+                                                <span>{{ form.scheduled_month_of_year.label }}</span>
+                                            </label>
+                                            <div class="control">
+                                                {{ form.scheduled_month_of_year }}
+                                                {{ form.scheduled_month_of_year.errors }}
+                                            </div>
+                                            <div id="{{ form.scheduled_month_of_year.id_for_label }}_errors">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <hr/>
+                        <!-- Load function parameters -->
+                        <div class="field">
+                            <div class="columns">
+                                <div class="column is-one-third">
+                                    <label for="{{ form.parameters.id_for_label }}">
+                                        <b class="title is-size-4">{{ form.parameters.label }}</b>
+                                        <span class="is-small has-text-grey-light">{{ form.parameters.label_suffix }}</span>
+                                        &nbsp;&nbsp;&nbsp;{{ form.parameters.help_text }}
+                                    </label>
+                                    <div class="column p-0 is-italic subtitle is-size-6">
+                                        Please enter the parameters for the function.
+                                    </div>
+                                    {{ form.parameters.errors }}
+                                </div>
+                                {% comment %} Render function param form if available. Else, lazy load. {% endcomment %}
+                                {% if task_parameter_form %}
+                                    <div class="column" id="function-parameters">
+                                        {{ task_parameter_form }}
+                                    </div>
+                                {% else %}
+                                    <div class="column"
+                                         id="function-parameters"
+                                         hx-trigger="load"
+                                         hx-get="{% url 'ui:function-parameters' %}"
+                                         hx-vals='{"function": "{{ function_id }}"}'>
+                                    </div>
+                                {% endif %}
+                            </div>
+                        </div>
+                        <hr/>
+                        {% if update %}
+                            <input class="button is-link" type="submit" value="Update"/>
                         {% else %}
-                            <div class="column" id="function-parameters" hx-trigger="load" hx-get="{% url 'ui:function-parameters' %}" hx-vals='{"function": "{{ function_id }}"}'>
-                            </div>
+                            <input class="button is-link" type="submit" value="Create"/>
                         {% endif %}
                     </div>
-                </div>
-
-                <hr/>
-                {% if update %}
-                    <input class="button is-link" type="submit" value="Update"/>
-                {% else %}
-                    <input class="button is-link" type="submit" value="Create"/>
-                {% endif %}
-            </div>
-        </form>
-    {% endif %}
-</div>
-{% endblock content %}
+                </form>
+            {% endif %}
+        </div>
+    {% endblock content %}

--- a/functionary/ui/templates/forms/scheduled_task/scheduled_task_edit.html
+++ b/functionary/ui/templates/forms/scheduled_task/scheduled_task_edit.html
@@ -203,7 +203,6 @@
                                     <div class="column p-0 is-italic subtitle is-size-6">
                                         Please enter the parameters for the function.
                                     </div>
-                                    {{ form.parameters.errors }}
                                 </div>
                                 {% comment %} Render function param form if available. Else, lazy load. {% endcomment %}
                                 {% if task_parameter_form %}
@@ -222,6 +221,7 @@
                         </div>
                         <hr/>
                         {% if update %}
+                            <input type="hidden" name="function" value="{{ scheduledtask.function_id }}"/>
                             <input class="button is-link" type="submit" value="Update"/>
                         {% else %}
                             <input class="button is-link" type="submit" value="Create"/>

--- a/functionary/ui/views/scheduled_task/create.py
+++ b/functionary/ui/views/scheduled_task/create.py
@@ -50,7 +50,9 @@ class ScheduledTaskCreateView(PermissionedCreateView):
 
         data["parameters"] = task_parameter_form.cleaned_data
         scheduled_task_form = ScheduledTaskForm(
-            data=data, environment=data["environment"]
+            data=data,
+            environment=data["environment"],
+            existing_errors=task_parameter_form.errors,
         )
         if scheduled_task_form.is_valid():
             scheduled_task = _create_scheduled_task(

--- a/functionary/ui/views/scheduled_task/create.py
+++ b/functionary/ui/views/scheduled_task/create.py
@@ -1,7 +1,7 @@
 from django.contrib import messages
 from django.db import transaction
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 
 from core.models import Environment, Function, ScheduledTask
@@ -44,31 +44,29 @@ class ScheduledTaskCreateView(PermissionedCreateView):
 
         task_parameter_form = TaskParameterForm(data["function"], data)
 
-        # Run is valid to clean fields and generate errors if present
-        if task_parameter_form.is_valid():
-            pass
-
-        data["parameters"] = task_parameter_form.cleaned_data
-        scheduled_task_form = ScheduledTaskForm(
-            data=data,
-            environment=data["environment"],
-            existing_errors=task_parameter_form.errors,
-        )
-        if scheduled_task_form.is_valid():
-            scheduled_task = _create_scheduled_task(
-                request,
-                scheduled_task_form.cleaned_data,
-                task_parameter_form.cleaned_data,
+        if not task_parameter_form.is_valid():
+            scheduled_task_form = self.get_form()
+        else:
+            data["parameters"] = task_parameter_form.cleaned_data
+            scheduled_task_form = ScheduledTaskForm(
+                data=data,
+                environment=data["environment"],
             )
-            return HttpResponseRedirect(
-                reverse("ui:scheduledtask-detail", kwargs={"pk": scheduled_task.id})
-            )
+            if scheduled_task_form.is_valid():
+                scheduled_task = _create_scheduled_task(
+                    request,
+                    scheduled_task_form.cleaned_data,
+                    task_parameter_form.cleaned_data,
+                )
+                return HttpResponseRedirect(
+                    reverse("ui:scheduledtask-detail", kwargs={"pk": scheduled_task.id})
+                )
 
         context = {
             "form": scheduled_task_form,
             "task_parameter_form": task_parameter_form,
         }
-        return render(request, "forms/scheduled_task/scheduled_task_edit.html", context)
+        return self.render_to_response(context)
 
 
 def _create_scheduled_task(

--- a/functionary/ui/views/scheduled_task/update.py
+++ b/functionary/ui/views/scheduled_task/update.py
@@ -1,5 +1,5 @@
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, QueryDict
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
 
 from core.models import Environment, ScheduledTask
@@ -52,24 +52,22 @@ class ScheduledTaskUpdateView(PermissionedUpdateView):
         data["function"] = scheduled_task.function
         task_parameter_form = TaskParameterForm(data["function"], data)
 
-        # Run is valid to clean fields and generate errors if present
-        if task_parameter_form.is_valid():
-            pass
+        if not task_parameter_form.is_valid():
+            form = self.get_form()
+        else:
+            data["parameters"] = task_parameter_form.cleaned_data
+            form = ScheduledTaskForm(
+                data=data,
+                environment=scheduled_task.environment,
+                instance=scheduled_task,
+            )
+            if form.is_valid():
+                form.save()
+                scheduled_task.set_status(form.cleaned_data["status"])
+                crontab_schedule = get_crontab_schedule(form.cleaned_data)
+                scheduled_task.set_schedule(crontab_schedule)
 
-        data["parameters"] = task_parameter_form.cleaned_data
-        form = ScheduledTaskForm(
-            data=data,
-            environment=scheduled_task.environment,
-            instance=scheduled_task,
-            existing_errors=task_parameter_form.errors,
-        )
-        if form.is_valid():
-            form.save()
-            scheduled_task.set_status(form.cleaned_data["status"])
-            crontab_schedule = get_crontab_schedule(form.cleaned_data)
-            scheduled_task.set_schedule(crontab_schedule)
-
-            return HttpResponseRedirect(self.get_success_url())
+                return HttpResponseRedirect(self.get_success_url())
 
         context = {
             "scheduledtask": scheduled_task,
@@ -77,4 +75,4 @@ class ScheduledTaskUpdateView(PermissionedUpdateView):
             "form": form,
             "task_parameter_form": task_parameter_form,
         }
-        return render(request, "forms/scheduled_task/scheduled_task_edit.html", context)
+        return self.render_to_response(context)

--- a/functionary/ui/views/scheduled_task/update.py
+++ b/functionary/ui/views/scheduled_task/update.py
@@ -58,7 +58,10 @@ class ScheduledTaskUpdateView(PermissionedUpdateView):
 
         data["parameters"] = task_parameter_form.cleaned_data
         form = ScheduledTaskForm(
-            data=data, environment=scheduled_task.environment, instance=scheduled_task
+            data=data,
+            environment=scheduled_task.environment,
+            instance=scheduled_task,
+            existing_errors=task_parameter_form.errors,
         )
         if form.is_valid():
             form.save()


### PR DESCRIPTION
Closes #196 

This PR allows Functionary to schedule functions that don't have parameters.  It also updates the ScheduledTask model to create PeriodicTasks with the ScheduledTask's id instead of name and adds an edit button the the ScheduledTask details page.

Testing:
Try create a scheduled task that takes JSON input. Put invalid JSON in the field so validation fails.  Check that there is only one error shown at the field instead of at the top of the form.
Create another similar task with invalid JSON, but also add an invalid character for one of the cron fields. Ensure both errors are shown on the form and nothing at the top. When you correct the JSON, verify that the cron error is still shown.