### PR TITLE
#213 - Added file param support for the API

### DIFF
--- a/examples/demo/functions.py
+++ b/examples/demo/functions.py
@@ -33,8 +33,9 @@ def variables():
     return [{"name": n, "value": v} for n, v in os.environ.items()]
 
 
-def num_chars(file: str) -> int:
+def num_chars(file: str, other_param: str) -> int:
     print(f"Fetching file from this URL: {file}")
+    print(f"Here is the other parameter: {other_param}")
     request = requests.get(file)
     if request.status_code == 200:
         return len(request.text)
@@ -67,13 +68,3 @@ def parameter_types(
         {"parameter": "string_", "type": type(string_).__name__, "value": string_},
         {"parameter": "text_", "type": type(text_).__name__, "value": text_},
     ]
-
-
-def num_chars_api(function: str, other_param: str) -> int:
-    """Test for API file param"""
-    print(f"Fetching function from this URL: {function}")
-    print(f"Here is the other parameter: {other_param}")
-    request = requests.get(function)
-    if request.status_code == 200:
-        return len(request.text)
-    return 0

--- a/examples/demo/functions.py
+++ b/examples/demo/functions.py
@@ -67,3 +67,13 @@ def parameter_types(
         {"parameter": "string_", "type": type(string_).__name__, "value": string_},
         {"parameter": "text_", "type": type(text_).__name__, "value": text_},
     ]
+
+
+def num_chars_api(function: str, other_param: str) -> int:
+    """Test for API file param"""
+    print(f"Fetching function from this URL: {function}")
+    print(f"Here is the other parameter: {other_param}")
+    request = requests.get(function)
+    if request.status_code == 200:
+        return len(request.text)
+    return 0

--- a/examples/demo/package.yaml
+++ b/examples/demo/package.yaml
@@ -65,18 +65,6 @@ package:
           description: Input file that will be measured
           type: file
           required: true
-    - name: num_chars_api
-      summary: Returns the number of characters in given file
-      display_name: Number of Characters API test
-      description: Returns the number of characters in given file
-      return_type: integer
-      parameters:
-        - name: function
-          display_name: Function
-          summary: File to measure
-          description: Input file that will be measured
-          type: file
-          required: true
         - name: other_param
           display_name: Other Param
           summary: Other param argument

--- a/examples/demo/package.yaml
+++ b/examples/demo/package.yaml
@@ -65,6 +65,24 @@ package:
           description: Input file that will be measured
           type: file
           required: true
+    - name: num_chars_api
+      summary: Returns the number of characters in given file
+      display_name: Number of Characters API test
+      description: Returns the number of characters in given file
+      return_type: integer
+      parameters:
+        - name: function
+          display_name: Function
+          summary: File to measure
+          description: Input file that will be measured
+          type: file
+          required: true
+        - name: other_param
+          display_name: Other Param
+          summary: Other param argument
+          description: Prints parameter
+          type: text
+          required: true
     - name: parameter_types
       summary: Test for parameter type form rendering and passthrough values
       display_name: Parameter Types

--- a/functionary/core/api/exceptions.py
+++ b/functionary/core/api/exceptions.py
@@ -16,9 +16,8 @@ def custom_exception_handler(exc, context):
         return None, resulting in a 500 error.
     """
     response = exception_handler(exc, context)
-    if response is not None:
+    if response is not None and isinstance(response.data, dict):
         response.data["code"] = exc.get_codes()
-
     return response
 
 

--- a/functionary/core/api/v1/serializers/task.py
+++ b/functionary/core/api/v1/serializers/task.py
@@ -90,9 +90,11 @@ class TaskCreateByNameSerializer(serializers.ModelSerializer):
                 package__name=package_name,
             )
             values["function"] = function
-        except Function.DoesNotExist as err:
+        except Function.DoesNotExist:
             exception_map = {
-                "function_name": f"No function {function_name} found for package {package_name}"
+                "function_name": (
+                    f"No function {function_name} found for package {package_name}"
+                )
             }
             exc = ValidationError(exception_map)
             raise serializers.ValidationError(serializers.as_serializer_error(exc))

--- a/functionary/core/api/v1/serializers/task.py
+++ b/functionary/core/api/v1/serializers/task.py
@@ -1,7 +1,10 @@
 """ Task serializers """
+from collections import OrderedDict
+
 from django.core.exceptions import ValidationError
 from rest_framework import serializers
 
+from core.api.v1.utils import parse_parameters
 from core.models import Function, Task
 
 
@@ -19,6 +22,11 @@ class TaskCreateByIdSerializer(serializers.ModelSerializer):
     class Meta:
         model = Task
         fields = ["function", "parameters"]
+
+    def to_internal_value(self, data) -> OrderedDict:
+        parse_parameters(data)
+        ret = super().to_internal_value(data)
+        return ret
 
     def create(self, validated_data):
         """Custom create that calls clean() on the task instance"""
@@ -40,6 +48,11 @@ class TaskCreateByNameSerializer(serializers.ModelSerializer):
     class Meta:
         model = Task
         fields = ["function_name", "package_name", "parameters"]
+
+    def to_internal_value(self, data) -> OrderedDict:
+        parse_parameters(data)
+        ret = super().to_internal_value(data)
+        return ret
 
     def create(self, validated_data):
         """Custom create that calls clean() on the task instance"""

--- a/functionary/core/api/v1/serializers/task.py
+++ b/functionary/core/api/v1/serializers/task.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from django.core.exceptions import ValidationError
 from rest_framework import serializers
 
-from core.api.v1.utils import parse_parameters
+from core.api.v1.utils import cast_parameters, parse_parameters
 from core.models import Function, Task
 
 
@@ -26,6 +26,7 @@ class TaskCreateByIdSerializer(serializers.ModelSerializer):
     def to_internal_value(self, data) -> OrderedDict:
         parse_parameters(data)
         ret = super().to_internal_value(data)
+        cast_parameters(ret)
         return ret
 
     def create(self, validated_data):
@@ -52,6 +53,7 @@ class TaskCreateByNameSerializer(serializers.ModelSerializer):
     def to_internal_value(self, data) -> OrderedDict:
         parse_parameters(data)
         ret = super().to_internal_value(data)
+        cast_parameters(ret)
         return ret
 
     def create(self, validated_data):

--- a/functionary/core/api/v1/utils.py
+++ b/functionary/core/api/v1/utils.py
@@ -64,6 +64,9 @@ def _cast_json_parameters(values: OrderedDict) -> None:
 
     for json_param in json_params:
         try:
+            if not values["parameters"].get(json_param.name):
+                continue
+
             if type(values["parameters"][json_param.name]) == dict:
                 continue
 

--- a/functionary/core/api/v1/utils.py
+++ b/functionary/core/api/v1/utils.py
@@ -4,6 +4,11 @@ from collections import OrderedDict
 from typing import Union
 
 from django.core.files.uploadedfile import InMemoryUploadedFile
+from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+
+from core.models import Function, FunctionParameter
+from core.utils.parameter import PARAMETER_TYPE
 
 PREFIX = "param"
 SEPARATOR = r"\."
@@ -17,7 +22,7 @@ def parse_parameters(values: OrderedDict) -> None:
 
     # Avoid dictionary changed size error by wrapping items in list
     for param, _ in list(values.items()):
-        if not (valid_param := r.match(param)):
+        if not (valid_param := get_parameter_name(param)):
             continue
 
         value = values.pop(param)
@@ -27,8 +32,78 @@ def parse_parameters(values: OrderedDict) -> None:
         values["parameters"][valid_param.group(2)] = value
 
 
+def cast_parameters(values: OrderedDict) -> None:
+    """Parent method to cast parameter necessary types"""
+    _cast_json_parameters(values)
+
+
 def get_parameter_name(parameter: str) -> Union[re.Match, None]:
+    """Return match if parameter name is of valid format"""
     return r.match(parameter)
+
+
+def _cast_json_parameters(values: OrderedDict) -> None:
+    """Mutates all JSON parameter fields into python objects
+
+    Args:
+        values: An OrderedDict containing the values passed to the serializer
+
+    Returns:
+        None
+
+    Raises:
+        ValidationError: When a JSON parameter is not valid JSON
+    """
+    function = _get_function(values)
+
+    json_params: list[FunctionParameter] = [
+        param
+        for param in function.parameters.all()
+        if param.parameter_type == PARAMETER_TYPE.JSON
+    ]
+
+    for json_param in json_params:
+        try:
+            if type(values["parameters"][json_param.name]) == dict:
+                continue
+
+            values["parameters"][json_param.name] = json.loads(
+                values["parameters"][json_param.name]
+            )
+        except json.decoder.JSONDecodeError as err:
+            exception_map = {json_param.name: err.msg}
+            exc = ValidationError(exception_map)
+            raise serializers.ValidationError(serializers.as_serializer_error(exc))
+
+
+def _get_function(values: OrderedDict) -> Function:
+    """Get the function from the internal values
+
+    Fetch the Function object from the values dictionary. If the `function` key
+    is not present, then we know the function name and package name serializer
+    was used. Since that serializer does not substitute the Function before
+    it's create method, we must fetch the function ourselves.
+
+    Args:
+        values: An ordered dict containing the values passed to the serializer
+
+    Returns:
+        function: The function object
+
+    Raises:
+        ValidationError: If the function was not found
+    """
+    try:
+        if not (function := values.get("function")):
+            function: Function = Function.objects.get(
+                name=values.get("function_name"),
+                package__name=values.get("package_name"),
+            )
+        return function
+    except Function.DoesNotExist as err:
+        exception_map = {"function_name": err}
+        exc = ValidationError(exception_map)
+        raise serializers.ValidationError(serializers.as_serializer_error(exc))
 
 
 def _update_parameter_field_type(values: OrderedDict) -> None:

--- a/functionary/core/api/v1/utils.py
+++ b/functionary/core/api/v1/utils.py
@@ -33,7 +33,7 @@ def parse_parameters(values: OrderedDict) -> None:
 
 
 def cast_parameters(values: OrderedDict) -> None:
-    """Parent method to cast parameter necessary types"""
+    """Parent method to cast parameters to necessary types"""
     _cast_json_parameters(values)
 
 

--- a/functionary/core/api/v1/utils.py
+++ b/functionary/core/api/v1/utils.py
@@ -1,0 +1,43 @@
+import json
+import re
+from collections import OrderedDict
+from typing import Union
+
+from django.core.files.uploadedfile import InMemoryUploadedFile
+
+PREFIX = "param"
+SEPARATOR = r"\."
+
+r = re.compile(rf"^({PREFIX}){SEPARATOR}(\w+)$")
+
+
+def parse_parameters(values: OrderedDict) -> None:
+    """Mutate given values to move all `param.` arguments in parameters field"""
+    _update_parameter_field_type(values)
+
+    # Avoid dictionary changed size error by wrapping items in list
+    for param, _ in list(values.items()):
+        if not (valid_param := r.match(param)):
+            continue
+
+        value = values.pop(param)
+        if type(value) == InMemoryUploadedFile:
+            value = value.name
+
+        values["parameters"][valid_param.group(2)] = value
+
+    # Dump parameters to JSON string for validation
+    # if values.get("parameters"):
+    #     values["parameters"] = json.dumps(values["parameters"])
+
+
+def get_parameter_name(parameter: str) -> Union[re.Match, None]:
+    return r.match(parameter)
+
+
+def _update_parameter_field_type(values: OrderedDict) -> None:
+    """Mutates the `parameters` field to a dictionary"""
+    if not values.get("parameters"):
+        values["parameters"] = {}
+    elif type(values.get("parameters")) == str:
+        values["parameters"] = json.loads(values["parameters"])

--- a/functionary/core/api/v1/utils.py
+++ b/functionary/core/api/v1/utils.py
@@ -26,10 +26,6 @@ def parse_parameters(values: OrderedDict) -> None:
 
         values["parameters"][valid_param.group(2)] = value
 
-    # Dump parameters to JSON string for validation
-    # if values.get("parameters"):
-    #     values["parameters"] = json.dumps(values["parameters"])
-
 
 def get_parameter_name(parameter: str) -> Union[re.Match, None]:
     return r.match(parameter)

--- a/functionary/core/api/v1/views/task.py
+++ b/functionary/core/api/v1/views/task.py
@@ -65,11 +65,7 @@ class TaskViewSet(
             "Parameters can be passed to the API either by prefixing them with "
             f"`{RENDER_PREFIX}`, or placing them inside a `parameters` JSON "
             "string. Prefixed parameters will **override** duplicate parameters "
-            "inside the parameters JSON string. "
-            "An example usage of parameters is as follows: "
-            "`-F 'param.file=@/path/to/README.md'` "
-            "`-F 'param.some_int'=5 'param.b'=20` "
-            '`-F \'parameters={"hello": "world"}\'`'
+            "inside the parameters JSON string."
         ),
         request=PolymorphicProxySerializer(
             component_name="TaskCreate",
@@ -160,9 +156,9 @@ def _handle_file_parameters(
         return
 
     # Wrap items in list to avoid dictionary changed size error
-    for param_name, _ in list(request.FILES.items()):
-        if param := get_parameter_name(param_name):
-            request.FILES[param.group(2)] = request.FILES.pop(param_name)[0]
+    for param, _ in list(request.FILES.items()):
+        if param_name := get_parameter_name(param):
+            request.FILES[param_name] = request.FILES.pop(param)[0]
 
     task = Task.objects.get(id=request_serializer.instance.id)
     _upload_files(task, request)

--- a/functionary/core/tests/api/v1/views/test_task.py
+++ b/functionary/core/tests/api/v1/views/test_task.py
@@ -41,7 +41,9 @@ def json_function(package: Package) -> Function:
         environment=package.environment,
     )
 
-    _function.parameters.create(name="prop1", parameter_type=PARAMETER_TYPE.JSON)
+    _function.parameters.create(
+        name="prop1", parameter_type=PARAMETER_TYPE.JSON, required=True
+    )
 
     return _function
 
@@ -279,6 +281,16 @@ def test_create_returns_400_for_invalid_parameters(
 
     assert response.status_code == 400
     assert task_id is None
+
+    task_input = {
+        "function_name": json_function.name,
+        "package_name": package.name,
+    }
+
+    response = admin_client.post(
+        url, data=task_input, content_type=MULTIPART_CONTENT, **request_headers
+    )
+    assert response.status_code == 400
 
 
 def test_no_result_returns_404(admin_client: Client, task: Task, request_headers: dict):

--- a/functionary/core/tests/api/v1/views/test_task.py
+++ b/functionary/core/tests/api/v1/views/test_task.py
@@ -1,4 +1,5 @@
 import json
+from io import BytesIO
 
 import pytest
 from django.test.client import MULTIPART_CONTENT, Client
@@ -161,14 +162,14 @@ def test_create_file_task(
 
     mocker.patch("core.api.v1.views.task._upload_files", mock_file_upload)
 
-    with open("core/tests/api/v1/views/test_text.txt", "rb") as f:
-        file_function_input = {"function": str(file_function.id), "prop1": f}
-        response = admin_client.post(
-            url,
-            data=file_function_input,
-            content_type=MULTIPART_CONTENT,
-            **request_headers,
-        )
+    example_file = BytesIO(b"Hello World!")
+    file_function_input = {"function": str(file_function.id), "prop1": example_file}
+    response = admin_client.post(
+        url,
+        data=file_function_input,
+        content_type=MULTIPART_CONTENT,
+        **request_headers,
+    )
 
     task_id = response.data.get("id")
 

--- a/functionary/core/tests/api/v1/views/test_text.txt
+++ b/functionary/core/tests/api/v1/views/test_text.txt
@@ -1,1 +1,0 @@
-Hello World!

--- a/functionary/core/tests/api/v1/views/test_text.txt
+++ b/functionary/core/tests/api/v1/views/test_text.txt
@@ -1,0 +1,1 @@
+Hello World!


### PR DESCRIPTION
Closes #213 

## Introduced Changes
- The `/api/v1/tasks` endpoint now handles file input in the same way as the UI
  - The only caveat is that you cannot submit Tasks that rely on file parameters through the Swagger UI

## Testing
- Publish the demo package to Functionary
- Fetch an authentication token from the API
  - `curl -X POST http://localhost:8000/api/v1/api-token-auth -H 'accept: application/json' -F "username=" -F "password="`
- Submit a task to the `num_chars_api` test function
  - `curl -X POST http://localhost:8000/api/v1/tasks/ -H 'accept: application/json' -H 'X-Environment-Id: <env uuid>' -H 'Content-Type: multipart/form-data' -F "function=<function uuid>" -F "file.function=@/path/to/file" -F 'parameters={"other_param": "hello world"}' -H "Authorization: Token <your auth token>"`
- Verify task runs as expected