### PR TITLE
Import local.py for additional settings if present

### DIFF
--- a/functionary/functionary/settings/debug.py
+++ b/functionary/functionary/settings/debug.py
@@ -17,7 +17,4 @@ INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + [
     "10.0.2.2",
 ]
 
-try:
-    from .local import *
-except ImportError:
-    pass
+from .local_settings import *  # noqa

--- a/functionary/functionary/settings/debug.py
+++ b/functionary/functionary/settings/debug.py
@@ -16,3 +16,8 @@ INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + [
     "127.0.0.1",
     "10.0.2.2",
 ]
+
+try:
+    from .local import *
+except ImportError:
+    pass

--- a/functionary/functionary/settings/local_settings.py
+++ b/functionary/functionary/settings/local_settings.py
@@ -1,0 +1,5 @@
+from .base import *  # noqa
+
+# Add overrides here like:
+# INSTALLED_APPS += ["django_watchfiles"]
+# MY_SETTINGS_VAR = "new_value"


### PR DESCRIPTION
This PR updates the `debug.py` settings to attempt to import from `local_settings.py`if available. Out of the box, this will add all new entries to the `django.conf.settings` with whatever values are in the `local_settings.py`. Any matching values will be overridden.
