### PR TITLE
#224 - Fix optional parameter handling when tasking through the UI

### DIFF
--- a/functionary/ui/forms/tasks.py
+++ b/functionary/ui/forms/tasks.py
@@ -148,6 +148,24 @@ class TaskParameterForm(Form):
         """
         return _field_mapping.get(parameter_type, (None, None))
 
+    def _remove_empty_fields(self, parameters: dict) -> None:
+        """Removes any fields that were empty (no value entered in the form) from the
+        parameters dict so they can be treated as optional values that weren't provided,
+        rather than values that were provided with the Field class's `empty_value`.
+        """
+        for name in list(parameters.keys()):
+            value = parameters[name]
+
+            if value is None or value == "":
+                _ = parameters.pop(name)
+
+    def clean(self):
+        """Form level validation and data cleanup"""
+        cleaned_data = super().clean()
+        self._remove_empty_fields(cleaned_data)
+
+        return cleaned_data
+
 
 class TaskParameterTemplateForm(TaskParameterForm):
     """TaskParameterForm variant with template variable support

--- a/functionary/ui/tests/views/test_function.py
+++ b/functionary/ui/tests/views/test_function.py
@@ -1,0 +1,65 @@
+"""Tests function views"""
+
+import pytest
+from django.urls import reverse
+
+from core.models import Function, Package, Task, Team
+from core.utils.parameter import PARAMETER_TYPE
+
+
+@pytest.fixture
+def environment():
+    team = Team.objects.create(name="team")
+    return team.environments.get()
+
+
+@pytest.fixture
+def package(environment):
+    return Package.objects.create(name="testpackage", environment=environment)
+
+
+@pytest.fixture
+def function(package):
+    return Function.objects.create(
+        name="testfunction",
+        package=package,
+        environment=package.environment,
+    )
+
+
+@pytest.fixture
+def integer_parameter(function):
+    return function.parameters.create(
+        name="optional_integer", parameter_type=PARAMETER_TYPE.INTEGER, required=False
+    )
+
+
+@pytest.fixture
+def string_parameter(function):
+    return function.parameters.create(
+        name="optional_string", parameter_type=PARAMETER_TYPE.STRING, required=False
+    )
+
+
+@pytest.mark.django_db
+def test_execute_handles_optional_parameters(
+    admin_client, function, integer_parameter, string_parameter
+):
+    """Optional parameters that are empty when the form is submitted should be excluded
+    from the Task parameters"""
+    session = admin_client.session
+    session["environment_id"] = str(function.environment.id)
+    session.save()
+
+    url = reverse("ui:function-execute")
+    data = {
+        "function_id": str(function.id),
+        f"task-parameter-{integer_parameter.name}": "",
+        f"task-parameter-{string_parameter.name}": "",
+    }
+
+    admin_client.post(url, data)
+    task = Task.objects.get(function=function)
+
+    assert integer_parameter.name not in task.parameters
+    assert string_parameter.name not in task.parameters


### PR DESCRIPTION
Closes #224 

This PR fixes optional parameter handling so that fields left blank on the tasking form are not saved as part of the Task parameters.  The prior behavior resulted in every parameter being included, with those that were blank on the form getting set to the Field class's `empty_value`, which is either `None` or `""` depending on the field type.

Note: boolean fields will always be included.  The empty value for a boolean is `False`, which makes sense, since that field being left blank on the form implies a value of `False`.

## Testing
A unit test has been added to ensure the proper behavior.  This can be easily manually tested by running the "long running process" example function and trying to execute with no value set for duration.  Previously this would result in a validation error.  Now it is accepted and the Task detail page will show the parameters as `{}`.