### PR TITLE
#223 - Fix pydantic BaseModel property shadowing in parameter validation

### DIFF
--- a/examples/demo/functions.py
+++ b/examples/demo/functions.py
@@ -1,6 +1,5 @@
 import os
 import time
-from datetime import date, datetime
 
 import requests
 
@@ -43,28 +42,28 @@ def num_chars(file: str, other_param: str) -> int:
 
 
 def parameter_types(
-    boolean_: bool | None = None,
-    date_: date | None = None,
-    datetime_: datetime | None = None,
-    file_: str | None = None,
-    float_: float | None = None,
-    integer_: int | None = None,
-    json_: dict | None = None,
-    string_: str | None = None,
-    text_: str | None = None,
+    boolean: bool | None = None,
+    date: str | None = None,
+    datetime: str | None = None,
+    file: str | None = None,
+    float: float | None = None,
+    integer: int | None = None,
+    json: dict | None = None,
+    string: str | None = None,
+    text: str | None = None,
 ):
     return [
-        {"parameter": "boolean_", "type": type(boolean_).__name__, "value": boolean_},
-        {"parameter": "date_", "type": type(date_).__name__, "value": date_},
+        {"parameter": "boolean", "type": type(boolean).__name__, "value": boolean},
+        {"parameter": "date", "type": type(date).__name__, "value": date},
         {
-            "parameter": "datetime_",
-            "type": type(datetime_).__name__,
-            "value": datetime_,
+            "parameter": "datetime",
+            "type": type(datetime).__name__,
+            "value": datetime,
         },
-        {"parameter": "file_", "type": type(file_).__name__, "value": file_},
-        {"parameter": "float_", "type": type(float_).__name__, "value": float_},
-        {"parameter": "integer_", "type": type(integer_).__name__, "value": integer_},
-        {"parameter": "json_", "type": type(json_).__name__, "value": json_},
-        {"parameter": "string_", "type": type(string_).__name__, "value": string_},
-        {"parameter": "text_", "type": type(text_).__name__, "value": text_},
+        {"parameter": "file", "type": type(file).__name__, "value": file},
+        {"parameter": "float", "type": type(float).__name__, "value": float},
+        {"parameter": "integer", "type": type(integer).__name__, "value": integer},
+        {"parameter": "json", "type": type(json).__name__, "value": json},
+        {"parameter": "string", "type": type(string).__name__, "value": string},
+        {"parameter": "text", "type": type(text).__name__, "value": text},
     ]

--- a/examples/demo/package.yaml
+++ b/examples/demo/package.yaml
@@ -79,30 +79,30 @@ package:
         the UI form rendering for the different types, as well as what data
         types and values get received by the underlying function.
       parameters:
-        - name: boolean_
+        - name: boolean
           type: boolean
           required: False
-        - name: date_
+        - name: date
           type: date
           required: False
-        - name: datetime_
+        - name: datetime
           type: datetime
           required: False
-        - name: file_
+        - name: file
           type: file
           required: False
-        - name: float_
+        - name: float
           type: float
           required: False
-        - name: integer_
+        - name: integer
           type: integer
           required: False
-        - name: json_
+        - name: json
           type: json
           required: False
-        - name: string_
+        - name: string
           type: string
           required: False
-        - name: text_
+        - name: text
           type: text
           required: False

--- a/functionary/core/tests/utils/test_parameter.py
+++ b/functionary/core/tests/utils/test_parameter.py
@@ -34,7 +34,7 @@ def function(package):
 @pytest.fixture
 def json_param(function):
     return FunctionParameter.objects.create(
-        name="json_param",
+        name="json",
         function=function,
         parameter_type=PARAMETER_TYPE.JSON,
         required=True,
@@ -77,27 +77,27 @@ def test_functions_without_parameters(function):
 @pytest.mark.django_db
 def test_missing_parameter(function, json_param, date_param):
     """Check for missing param2"""
-    with pytest.raises(ValidationError, match=r".*date_param.*"):
+    with pytest.raises(ValidationError, match=rf".*{date_param.name}.*"):
         validate_parameters({json_param.name: {"hello": 1}}, function)
 
 
 @pytest.mark.django_db
 def test_incorrect_parameters(function, json_param):
     """Check that incorrect parameters don't work."""
-    with pytest.raises(ValidationError, match=r".*json_param.*required.*"):
+    with pytest.raises(ValidationError, match=rf".*{json_param.name}.*required.*"):
         validate_parameters({}, function)
 
-    with pytest.raises(ValidationError, match=r".*json_param.*required.*"):
+    with pytest.raises(ValidationError, match=rf".*{json_param.name}.*required.*"):
         validate_parameters({"true": False}, function)
 
 
 @pytest.mark.django_db
 def test_incorrect_parameter_type(function, json_param, date_param):
     """Check that parameters with an incorrect type don't work."""
-    with pytest.raises(ValidationError, match=r".*date_param.*"):
+    with pytest.raises(ValidationError, match=rf".*{date_param.name}.*"):
         validate_parameters({json_param.name: 1, date_param.name: False}, function)
 
-    with pytest.raises(ValidationError, match=r".*date_param.*"):
+    with pytest.raises(ValidationError, match=rf".*{date_param.name}.*"):
         validate_parameters({json_param.name: 1, date_param.name: "False"}, function)
 
 

--- a/functionary/core/utils/parameter.py
+++ b/functionary/core/utils/parameter.py
@@ -54,7 +54,8 @@ def _get_pydantic_model(instance: Union["Function", "Workflow"]) -> Type[BaseMod
         field.default = ... if parameter.required else parameter.default
         type_ = _PARAMETER_TYPE_MAP[parameter.parameter_type]
 
-        params_dict[field.alias] = (type_, field)
+        # Append _ to ensure name does not conflict with pydantic BaseModel properties
+        params_dict[f"{field.alias}_"] = (type_, field)
 
     model_name = f"{type(instance).__name__}ParameterModel"
 


### PR DESCRIPTION
Closes #223 

This PR fixes the issue of function parameter names not being able to validate if they shadow properties of pydantic's BaseModel (i.e. "json").

The actual fix is a one liner in [functionary/core/utils/parameter.py](https://github.com/beer-garden/functionary/compare/main...scott-taubman:223-pydantic-basemodel-collision-fix?expand=1#diff-c454bb02aef11ce5ab31c885aa281fc1409da80c936fe968eab00a4fad2695ea).  The rest is updates to the example function and some of the unit tests.

## Test Instructions
* The validation unit tests were updated so that the `json_param` fixture now uses one of the problematic names: "json". The one change would make all of the tests fail before this fix.  With the change, they continue to pass.
* The `parameter_types` demo function no longer appends `_` to the parameter names, which was done previously as a workaround to this specific problem.  Publishing and tasking this updated version should work fine rather than yelling at you about the parameter named "json".