### PR TITLE
Fix environment selector rendering

### DIFF
--- a/functionary/functionary/settings/base/__init__.py
+++ b/functionary/functionary/settings/base/__init__.py
@@ -96,6 +96,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "ui.views.utils.user_environments",
             ],
         },
     },

--- a/functionary/ui/templates/forms/environment_selector.html
+++ b/functionary/ui/templates/forms/environment_selector.html
@@ -11,7 +11,7 @@
         <option disabled value="-1">
             Choose
         </option>
-        {% for team, envs in environments.items %}
+        {% for team, envs in user_environments.items %}
             <optgroup label="{{ team }}">
                 {% for env in envs %}
                     <option value="{{ env.id }}"

--- a/functionary/ui/templates/partials/env_selector.html
+++ b/functionary/ui/templates/partials/env_selector.html
@@ -1,7 +1,3 @@
-<div hx-trigger="load"
-     hx-get="{% url 'ui:set-environment' %}?next={{ request.get_full_path }}"
-     hx-target="#set-env-form"
-     hx-swap="innerHTML">
-    <form id="set-env-form">
-    </form>
-</div>
+<form id="set-env-form">
+    {% include "forms/environment_selector.html" %}
+</form>

--- a/functionary/ui/tests/views/test_environment_select.py
+++ b/functionary/ui/tests/views/test_environment_select.py
@@ -43,20 +43,6 @@ def user_without_access():
 
 
 @pytest.mark.django_db
-def test_environment_select_get(
-    client, environment, environment_with_no_users, user_with_access
-):
-    client.force_login(user_with_access)
-
-    url = reverse("ui:set-environment")
-    response = client.get(url)
-    response_body = response.content.decode()
-
-    assert str(environment.id) in response_body
-    assert str(environment_with_no_users.id) not in response_body
-
-
-@pytest.mark.django_db
 def test_environment_select_post(client, environment, user_with_access):
     client.force_login(user_with_access)
 

--- a/functionary/ui/tests/views/test_utils.py
+++ b/functionary/ui/tests/views/test_utils.py
@@ -4,7 +4,7 @@ import pytest
 
 from core.auth import Role
 from core.models import EnvironmentUserRole, Team, User
-from ui.views.utils import set_session_environment
+from ui.views.utils import set_session_environment, user_environments
 
 
 @pytest.fixture
@@ -41,3 +41,14 @@ def test_set_session_environment(environment, user):
     # User with READ_ONLY role should *not* have non-read permissions
     assert request.session["user_can_create_function"] is False
     assert request.session["user_can_create_task"] is False
+
+
+@pytest.mark.django_db
+def test_user_environments(environment, user):
+    """user's environments are returned by the user_environments context processor"""
+    request = Mock()
+    request.user = user
+
+    context = user_environments(request)
+
+    assert environment in context["user_environments"][environment.team.name]

--- a/functionary/ui/views/environment_select.py
+++ b/functionary/ui/views/environment_select.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.http import HttpRequest
-from django.shortcuts import render
 from django.views.generic import TemplateView
 from django_htmx import http
 
@@ -20,17 +19,3 @@ class EnvironmentSelectView(LoginRequiredMixin, TemplateView):
         set_session_environment(request, environment)
 
         return http.HttpResponseClientRedirect("/ui")
-
-    def get(self, request: HttpRequest):
-        envs = self.request.user.environments.select_related("team").order_by(
-            "team__name", "name"
-        )
-
-        environments = {}
-        for env in envs:
-            environments.setdefault(env.team.name, []).append(env)
-
-        self.extra_context = {"environments": environments}
-        context = self.get_context_data()
-
-        return render(request, "forms/environment_selector.html", context)

--- a/functionary/ui/views/utils.py
+++ b/functionary/ui/views/utils.py
@@ -51,3 +51,25 @@ def set_session_environment(request: HttpRequest, environment: Environment) -> N
     """
     request.session["environment_id"] = str(environment.id)
     _load_session_permissions(request, environment)
+
+
+def user_environments(request: HttpRequest) -> dict:
+    """Context processor function that adds the user's environments to the context
+
+    Args:
+        request: The HttpRequest to base the context on
+
+    Returns:
+        A dict containing "user_environments" to be appended to the template context
+    """
+    environments = {}
+
+    if hasattr(request.user, "environments"):
+        envs = request.user.environments.select_related("team").order_by(
+            "team__name", "name"
+        )
+
+        for env in envs:
+            environments.setdefault(env.team.name, []).append(env)
+
+    return {"user_environments": environments}


### PR DESCRIPTION
This PR updates the handling of the environment selector drop down so that it doesn't flash in and out as it's re-rendering on every page load.

What I've done is moved the logic that was in `EnvironmentSelectView` into a context processor so that the user environment data gets stamped into the context automatically (whenever `get_context_data()` is called).  That lets us get out of having to do the lazy load of the environment selector and can instead just render it directly as part of the main template rendering.

## Test Instructions
* Note the current behavior of the env selector dropdown flashing in and out as you change pages.
* On this branch that should no longer be the case.