### PR TITLE
#241 - Added failed file upload error handling

### DIFF
--- a/functionary/core/api/v1/views/task.py
+++ b/functionary/core/api/v1/views/task.py
@@ -27,7 +27,7 @@ from core.api.v1.serializers import (
 from core.api.v1.utils import PREFIX, SEPARATOR, get_parameter_name
 from core.api.viewsets import EnvironmentGenericViewSet
 from core.models import Task, TaskResult
-from core.utils.minio import S3FileUploadError, handle_file_parameters
+from core.utils.minio import S3Error, handle_file_parameters
 
 RENDER_PREFIX = f"{PREFIX}{SEPARATOR}".replace("\\", "")
 
@@ -106,7 +106,7 @@ class TaskViewSet(
             task.save()
         except (ValidationError, DjangoValidationError) as err:
             raise serializers.ValidationError(serializers.as_serializer_error(err))
-        except S3FileUploadError as err:
+        except S3Error as err:
             return Response(
                 {"error": f"{err}"},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/functionary/core/api/v1/views/task.py
+++ b/functionary/core/api/v1/views/task.py
@@ -27,7 +27,7 @@ from core.api.v1.serializers import (
 from core.api.v1.utils import PREFIX, SEPARATOR, get_parameter_name
 from core.api.viewsets import EnvironmentGenericViewSet
 from core.models import Task, TaskResult
-from core.utils.minio import handle_file_parameters
+from core.utils.minio import S3FileUploadError, handle_file_parameters
 
 RENDER_PREFIX = f"{PREFIX}{SEPARATOR}".replace("\\", "")
 
@@ -106,6 +106,11 @@ class TaskViewSet(
             task.save()
         except (ValidationError, DjangoValidationError) as err:
             raise serializers.ValidationError(serializers.as_serializer_error(err))
+        except S3FileUploadError as err:
+            return Response(
+                {"error": f"{err}"},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
 
         response_serializer = TaskCreateResponseSerializer(task)
 
@@ -169,8 +174,4 @@ def _handle_file_parameters(
         if param_name := get_parameter_name(param):
             request.FILES[param_name] = request.FILES.pop(param)[0]
 
-    _upload_files(task, request)
-
-
-def _upload_files(task: Task, request: Request) -> None:
     handle_file_parameters(task, request)

--- a/functionary/core/tests/api/v1/views/test_task.py
+++ b/functionary/core/tests/api/v1/views/test_task.py
@@ -257,7 +257,7 @@ def test_fail_file_upload(
 
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert task_id is None
-    assert not Task.objects.filter(id=task_id).exists()
+    assert not Task.objects.filter(function=file_function).exists()
 
 
 def test_create_returns_400_for_invalid_parameters(

--- a/functionary/ui/views/function.py
+++ b/functionary/ui/views/function.py
@@ -13,11 +13,7 @@ from django.views.decorators.http import require_GET, require_POST
 
 from core.auth import Permission
 from core.models import Environment, Function, Task
-from core.utils.minio import (
-    S3ConnectionError,
-    S3FileUploadError,
-    handle_file_parameters,
-)
+from core.utils.minio import S3Error, handle_file_parameters
 from ui.forms.tasks import TaskParameterForm, TaskParameterTemplateForm
 from ui.tables.function import FunctionTable
 
@@ -105,7 +101,7 @@ def execute(request: HttpRequest) -> HttpResponse:
                     code="invalid",
                 ),
             )
-        except S3ConnectionError:
+        except S3Error:
             status_code = 503
             form.add_error(
                 None,
@@ -114,9 +110,6 @@ def execute(request: HttpRequest) -> HttpResponse:
                     "If the problem persists, contact your system administrator."
                 ),
             )
-        except S3FileUploadError:
-            status_code = 503
-            form.add_error(None, "Failed to upload given file(s).")
 
     args = {"form": form, "function": func}
     return render(request, "core/function_detail.html", args, status=status_code)

--- a/functionary/ui/views/function.py
+++ b/functionary/ui/views/function.py
@@ -13,7 +13,11 @@ from django.views.decorators.http import require_GET, require_POST
 
 from core.auth import Permission
 from core.models import Environment, Function, Task
-from core.utils.minio import S3ConnectionError, handle_file_parameters
+from core.utils.minio import (
+    S3ConnectionError,
+    S3FileUploadError,
+    handle_file_parameters,
+)
 from ui.forms.tasks import TaskParameterForm, TaskParameterTemplateForm
 from ui.tables.function import FunctionTable
 
@@ -110,6 +114,9 @@ def execute(request: HttpRequest) -> HttpResponse:
                     "If the problem persists, contact your system administrator."
                 ),
             )
+        except S3FileUploadError:
+            status_code = 503
+            form.add_error(None, "Failed to upload given file(s).")
 
     args = {"form": form, "function": func}
     return render(request, "core/function_detail.html", args, status=status_code)


### PR DESCRIPTION
Closes #241 

## Introduced Changes
- Added a `S3FileUploadError` exception
  - Raised when `client.put_file` raises any exception
- API and UI return an error claiming that the file(s) were not able to be uploaded with a status of `503`

## Testing
- Added unit tests for API and views
- To manually test, simply raise the `S3FileUploadError` before the `client.put_file` in `minio.py` to view the errors that get returned or rendered