### PR TITLE
248 - Add inidicator for how the tables are sorted

### DIFF
--- a/functionary/ui/static/css/functionary.css
+++ b/functionary/ui/static/css/functionary.css
@@ -53,3 +53,22 @@ tr.htmx-swapping td {
 body div aside {
     max-width: fit-content;
 }
+
+/* table sorting indicators */
+th.asc::after {
+    content: '\f077';    /* chevron-up */
+    font-family: var(--fa-style-family,"Font Awesome 6 Free");
+    color: var(--bs-primary);
+    font-size: 0.75em;
+    line-height: .05em;
+    vertical-align: -.1em;
+    padding-left: .5em;
+}
+th.desc::after {
+    content: '\f078';    /* chevron-down */
+    font-family: var(--fa-style-family,"Font Awesome 6 Free");
+    color: var(--bs-primary);
+    font-size: 0.75em;
+    line-height: .05em;
+    padding-left: .5em;
+}

--- a/functionary/ui/static/css/functionary.css
+++ b/functionary/ui/static/css/functionary.css
@@ -55,20 +55,17 @@ body div aside {
 }
 
 /* table sorting indicators */
-th.asc::after {
-    content: '\f077';    /* chevron-up */
+th.asc::after,
+th.desc::after {
     font-family: var(--fa-style-family,"Font Awesome 6 Free");
     color: var(--bs-primary);
     font-size: 0.75em;
     line-height: .05em;
-    vertical-align: -.1em;
     padding-left: .5em;
+}
+th.asc::after {
+    content: '\f077';    /* chevron-up */
 }
 th.desc::after {
     content: '\f078';    /* chevron-down */
-    font-family: var(--fa-style-family,"Font Awesome 6 Free");
-    color: var(--bs-primary);
-    font-size: 0.75em;
-    line-height: .05em;
-    padding-left: .5em;
 }


### PR DESCRIPTION
Closes #248 

This PR adds some css styling to the already present "asc" and "desc" classes so that an indicator gets displayed on the column headers to show the current sorting.

## Test Instructions
* Go to any of the list views and sort.  You should see an indicator showing which way the sort is going.  Tasking and Builds are sorted by their date columns by default, so those show indicators even on the initial load.