### PR TITLE
179 Cleanup package tarball

### DIFF
--- a/cli/.vscode/launch.json
+++ b/cli/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "cli - attach",
+      "type": "python",
+      "request": "attach",
+      "connect": {
+        "host": "localhost",
+        "port": 56789
+      },
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}",
+          "remoteRoot": "."
+        }
+      ]
+    }
+  ]
+}

--- a/cli/functionary/functionary.py
+++ b/cli/functionary/functionary.py
@@ -13,3 +13,6 @@ def cli():
 cli.add_command(login_cmd)
 cli.add_command(package_cmd)
 cli.add_command(environment_cmd)
+
+if __name__ == "__main__":
+    cli()

--- a/cli/functionary/package.py
+++ b/cli/functionary/package.py
@@ -96,17 +96,16 @@ def create_cmd(ctx, language, name, output_directory):
 @package_cmd.command()
 @click.argument("path", type=click.Path(exists=True))
 @click.option(
-    "--keep", "-k", is_flag=True, help="Keep the tarball rather than cleaning it up"
+    "--keep",
+    "-k",
+    is_flag=True,
+    help="Keep build artifacts after publishing, rather than cleaning them up",
 )
 @click.pass_context
 def publish(ctx, path, keep):
     """
-    Create an archive from the project and publish to the build server.
+    Publish a package to make it available in the currently active environment.
 
-    This will create an archive of the files at the given path and
-    then publish them to the build server for image creation.
-    Use the -t option to specify a token or set the FUNCTIONARY_TOKEN
-    environment variable after logging in to Functionary.
     Use the -k option to keep the build artifacts
     (found in $HOME/.functionary/builds) after publishing,
     rather than cleaning it up.
@@ -128,6 +127,7 @@ def publish(ctx, path, keep):
 
 
 def get_tar_path(tar_name):
+    """Construct the path to the package tarball"""
     tar_name = tar_name + ".tar.gz"
     tar_path = pathlib.Path.joinpath(pathlib.Path.home(), ".functionary")
     pathlib.Path(tar_path, "builds").mkdir(parents=True, exist_ok=True)

--- a/cli/functionary/package.py
+++ b/cli/functionary/package.py
@@ -95,8 +95,11 @@ def create_cmd(ctx, language, name, output_directory):
 
 @package_cmd.command()
 @click.argument("path", type=click.Path(exists=True))
+@click.option(
+    "--keep", "-k", is_flag=True, help="Keep the tarball rather than cleaning it up"
+)
 @click.pass_context
-def publish(ctx, path):
+def publish(ctx, path, keep):
     """
     Create an archive from the project and publish to the build server.
 
@@ -104,19 +107,31 @@ def publish(ctx, path):
     then publish them to the build server for image creation.
     Use the -t option to specify a token or set the FUNCTIONARY_TOKEN
     environment variable after logging in to Functionary.
+    Use the -k option to keep the build artifacts
+    (found in $HOME/.functionary/builds) after publishing,
+    rather than cleaning it up.
     """
     host = get_config_value("host", raise_exception=True)
-
     full_path = pathlib.Path(path).resolve()
-    tarfile_name = full_path.joinpath(f"{full_path.name}.tar.gz")
-    with tarfile.open(str(tarfile_name), "w:gz") as tar:
+    tar_path = get_tar_path(full_path.name)
+
+    with tarfile.open(str(tar_path), "w:gz") as tar:
         tar.add(str(full_path), arcname="")
 
-    with open(tarfile_name, "rb") as upload_file:
-        click.echo(f"Publishing {str(tarfile_name)} package to {host}")
+    with open(tar_path, "rb") as upload_file:
+        click.echo(f"Publishing {str(tar_path)} package to {host}")
         response = post("publish", files={"package_contents": upload_file})
+        if keep is False:
+            os.remove(tar_path)
         id = response["id"]
         click.echo(f"Package upload complete\nBuild id: {id}")
+
+
+def get_tar_path(tar_name):
+    tar_name = tar_name + ".tar.gz"
+    tar_path = pathlib.Path.joinpath(pathlib.Path.home(), ".functionary")
+    pathlib.Path(tar_path, "builds").mkdir(parents=True, exist_ok=True)
+    return pathlib.Path.joinpath(tar_path, "builds", tar_name)
 
 
 @package_cmd.command()

--- a/cli/tests/test_package.py
+++ b/cli/tests/test_package.py
@@ -1,0 +1,57 @@
+import os
+import pathlib
+
+import pytest
+import requests
+from click.testing import CliRunner
+
+from functionary.config import save_config_value
+from functionary.package import get_tar_path, publish
+
+
+def response_200(*args, **kwargs):
+    response = requests.Response()
+    response.status_code = 200
+    response._content = b"""{
+        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "creator": {
+            "id": 0
+        },
+        "package": {"id": "3fa85f64-5717-4562-b3fc-2c963f66afa6", "name": "string"},
+        "created_at": "2023-03-06T18:24:05.051Z",
+        "updated_at": "2023-03-06T18:24:05.051Z",
+        "status": "PENDING",
+        "environment": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+    }"""
+
+    return response
+
+
+@pytest.mark.usefixtures("config")
+def test_publish_with_keep(fakefs, monkeypatch):
+    """Call publish with --keep : Keep build artifacts rather than cleaning them up"""
+    monkeypatch.setattr(requests, "post", response_200)
+    os.environ["HOME"] = "/tmp/test_home"
+    fakefs.create_file(pathlib.Path.home() / "tar_this.txt")
+
+    host = "http://test:1234"
+    save_config_value("host", host)
+
+    runner = CliRunner()
+    runner.invoke(publish, [str(pathlib.Path.home()), "--keep"])
+    assert os.path.isfile(get_tar_path(pathlib.Path.home().name))
+
+
+@pytest.mark.usefixtures("config")
+def test_publish_without_keep(fakefs, monkeypatch):
+    """Call publish without --keep : Cleaning up build artifacts after publishing"""
+    monkeypatch.setattr(requests, "post", response_200)
+    os.environ["HOME"] = "/tmp/test_home"
+    fakefs.create_file(pathlib.Path.home() / "tar_this.txt")
+
+    host = "http://test:1234"
+    save_config_value("host", host)
+
+    runner = CliRunner()
+    runner.invoke(publish, [str(pathlib.Path.home())])
+    assert not os.path.isfile(get_tar_path(pathlib.Path.home().name))


### PR DESCRIPTION
This PR adds the option of -k or --keep to the publish command which will result in the demo tar file being stored in ~/.functionary/builds/. If the publish command is ran without the option (-k/--keep) it will simply be cleaned up after the operation is finished.


### Testing Instructions
` functionary package publish examples/demo` - Should result the tar file being cleaned up
`functionary package publish examples/demo --keep` - Should result in a tar file being stored in the ./functionary/builds/ folder
In addition 2 tests added to test_package.py
