### PR TITLE
#201 - workflow detail

### DIFF
--- a/functionary/ui/forms/workflow_step.py
+++ b/functionary/ui/forms/workflow_step.py
@@ -39,7 +39,7 @@ class WorkflowStepCreateForm(forms.ModelForm):
         # Add htmx attributes to the function widget
         self.fields["function"].widget.attrs.update(
             {
-                "class": "input",
+                "class": "form-control",
                 "hx-get": reverse("ui:function-parameters"),
                 "hx-vals": '{"allow_template_variables": "true"}',
                 "hx-target": "#function-parameters",

--- a/functionary/ui/scss/custom.scss
+++ b/functionary/ui/scss/custom.scss
@@ -20,7 +20,7 @@ $primary: #3E5F8E;
 $secondary: #FFFFFF;
 $danger: #8A1B19;
 $warning: #FFCDA3;
-$info: #7CAFB6;
+$info: #407f87;
 $success: #5A7A57;
 $light: #F7F8F8;
 $dark: #343E40;

--- a/functionary/ui/static/css/custom_bootstrap.css
+++ b/functionary/ui/static/css/custom_bootstrap.css
@@ -39,7 +39,7 @@
   --bs-primary: #3E5F8E;
   --bs-secondary: #FFFFFF;
   --bs-success: #5A7A57;
-  --bs-info: #7CAFB6;
+  --bs-info: #407f87;
   --bs-warning: #FFCDA3;
   --bs-danger: #8A1B19;
   --bs-light: #F7F8F8;
@@ -47,7 +47,7 @@
   --bs-primary-rgb: 62, 95, 142;
   --bs-secondary-rgb: 255, 255, 255;
   --bs-success-rgb: 90, 122, 87;
-  --bs-info-rgb: 124, 175, 182;
+  --bs-info-rgb: 64, 127, 135;
   --bs-warning-rgb: 255, 205, 163;
   --bs-danger-rgb: 138, 27, 25;
   --bs-light-rgb: 247, 248, 248;
@@ -1752,13 +1752,13 @@ progress {
 
 .table-info {
   --bs-table-color: #000;
-  --bs-table-bg: #e5eff0;
-  --bs-table-border-color: #ced7d8;
-  --bs-table-striped-bg: #dae3e4;
+  --bs-table-bg: #d9e5e7;
+  --bs-table-border-color: #c3ced0;
+  --bs-table-striped-bg: #cedadb;
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #ced7d8;
+  --bs-table-active-bg: #c3ced0;
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #d4ddde;
+  --bs-table-hover-bg: #c9d4d6;
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -2754,20 +2754,20 @@ textarea.form-control-lg {
 }
 
 .btn-info {
-  --bs-btn-color: #000;
-  --bs-btn-bg: #7CAFB6;
-  --bs-btn-border-color: #7CAFB6;
-  --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #90bbc1;
-  --bs-btn-hover-border-color: #89b7bd;
-  --bs-btn-focus-shadow-rgb: 105, 149, 155;
-  --bs-btn-active-color: #000;
-  --bs-btn-active-bg: #96bfc5;
-  --bs-btn-active-border-color: #89b7bd;
+  --bs-btn-color: #fff;
+  --bs-btn-bg: #407f87;
+  --bs-btn-border-color: #407f87;
+  --bs-btn-hover-color: #fff;
+  --bs-btn-hover-bg: #366c73;
+  --bs-btn-hover-border-color: #33666c;
+  --bs-btn-focus-shadow-rgb: 93, 146, 153;
+  --bs-btn-active-color: #fff;
+  --bs-btn-active-bg: #33666c;
+  --bs-btn-active-border-color: #305f65;
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #000;
-  --bs-btn-disabled-bg: #7CAFB6;
-  --bs-btn-disabled-border-color: #7CAFB6;
+  --bs-btn-disabled-color: #fff;
+  --bs-btn-disabled-bg: #407f87;
+  --bs-btn-disabled-border-color: #407f87;
 }
 
 .btn-warning {
@@ -2890,19 +2890,19 @@ textarea.form-control-lg {
 }
 
 .btn-outline-info {
-  --bs-btn-color: #7CAFB6;
-  --bs-btn-border-color: #7CAFB6;
-  --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #7CAFB6;
-  --bs-btn-hover-border-color: #7CAFB6;
-  --bs-btn-focus-shadow-rgb: 124, 175, 182;
-  --bs-btn-active-color: #000;
-  --bs-btn-active-bg: #7CAFB6;
-  --bs-btn-active-border-color: #7CAFB6;
+  --bs-btn-color: #407f87;
+  --bs-btn-border-color: #407f87;
+  --bs-btn-hover-color: #fff;
+  --bs-btn-hover-bg: #407f87;
+  --bs-btn-hover-border-color: #407f87;
+  --bs-btn-focus-shadow-rgb: 64, 127, 135;
+  --bs-btn-active-color: #fff;
+  --bs-btn-active-bg: #407f87;
+  --bs-btn-active-border-color: #407f87;
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #7CAFB6;
+  --bs-btn-disabled-color: #407f87;
   --bs-btn-disabled-bg: transparent;
-  --bs-btn-disabled-border-color: #7CAFB6;
+  --bs-btn-disabled-border-color: #407f87;
   --bs-gradient: none;
 }
 
@@ -3834,12 +3834,12 @@ textarea.form-control-lg {
 }
 
 .alert-info {
-  --bs-alert-color: #4a696d;
-  --bs-alert-bg: #e5eff0;
-  --bs-alert-border-color: #d8e7e9;
+  --bs-alert-color: #264c51;
+  --bs-alert-bg: #d9e5e7;
+  --bs-alert-border-color: #c6d9db;
 }
 .alert-info .alert-link {
-  color: #3b5457;
+  color: #1e3d41;
 }
 
 .alert-warning {
@@ -4765,8 +4765,8 @@ textarea.form-control-lg {
 }
 
 .text-bg-info {
-  color: #000 !important;
-  background-color: RGBA(124, 175, 182, var(--bs-bg-opacity, 1)) !important;
+  color: #fff !important;
+  background-color: RGBA(64, 127, 135, var(--bs-bg-opacity, 1)) !important;
 }
 
 .text-bg-warning {
@@ -4811,10 +4811,10 @@ textarea.form-control-lg {
 }
 
 .link-info {
-  color: #7CAFB6 !important;
+  color: #407f87 !important;
 }
 .link-info:hover, .link-info:focus {
-  color: #96bfc5 !important;
+  color: #33666c !important;
 }
 
 .link-warning {

--- a/functionary/ui/templates/account/login.html
+++ b/functionary/ui/templates/account/login.html
@@ -77,7 +77,7 @@
                                 {{ form.non_field_errors }}
                             </div>
                             <div class="card-footer text-center bg-body">
-                                <button class="btn btn-success text-light" form="loginForm" type="submit">Sign In</button>
+                                <button class="btn btn-primary text-light" form="loginForm" type="submit">Sign In</button>
                             </div>
                         </div>
                     {% endblock content %}

--- a/functionary/ui/templates/builder/build_detail.html
+++ b/functionary/ui/templates/builder/build_detail.html
@@ -13,7 +13,7 @@
         </nav>
         <div class="hstack gap-3 pt-2 pb-4">
             <h1>
-                <i class="fa fa-wrench fa-xl"></i>
+                <i class="fa fa-wrench"></i>
                 {{ build.package.render_name }}
             </h1>
             <div>

--- a/functionary/ui/templates/core/package_detail.html
+++ b/functionary/ui/templates/core/package_detail.html
@@ -10,7 +10,7 @@
             </ol>
         </nav>
         <h1 class="pt-2 pb-4">
-            <i class="fa fa-cubes fa-xl"></i>
+            <i class="fa fa-cubes"></i>
             {{ package.render_name }}
         </h1>
         <div class="vstack gap-4 py-2">

--- a/functionary/ui/templates/core/task_detail.html
+++ b/functionary/ui/templates/core/task_detail.html
@@ -12,7 +12,7 @@
         </nav>
         <div class="hstack gap-3 pt-2 pb-4">
             <h1>
-                <i class="fa fa-digital-tachograph fa-xl"></i>
+                <i class="fa fa-digital-tachograph"></i>
                 {{ task.function.render_name }}
             </h1>
             <div>

--- a/functionary/ui/templates/core/workflow_detail.html
+++ b/functionary/ui/templates/core/workflow_detail.html
@@ -13,14 +13,12 @@
             <i class="fa fa-diagram-next"></i>
             {{ workflow.name }}
         </h1>
-        <div>
-            <i class="fa fa-pencil-alt fa-lg text-info"
-               type="button"
-               title="Edit"
-               hx-target="body"
-               hx-swap="beforeend"
-               hx-get="{% url 'ui:workflow-update' workflow.id %}?id={{ workflow.id }}"></i>
-        </div>
+        <i class="fa fa-pencil-alt fa-lg text-info"
+           type="button"
+           title="Edit"
+           hx-target="body"
+           hx-swap="beforeend"
+           hx-get="{% url 'ui:workflow-update' workflow.id %}?id={{ workflow.id }}"></i>
     </div>
     <div class="vstack gap-4 py-2">
         <div>

--- a/functionary/ui/templates/core/workflow_detail.html
+++ b/functionary/ui/templates/core/workflow_detail.html
@@ -25,7 +25,13 @@
             <strong class="fs-4"><i class="fa fa-newspaper fa-sm fa-fw pe-1"></i>Description</strong>
             <p id="desc" class="ps-4 py-2">{{ workflow.description }}</p>
         </div>
-        {% include "partials/workflows/parameter_list.html" %}
-        {% include "partials/workflows/step_list.html" %}
+        <div>
+            <strong class="fs-4"><i class="fa fa-list fa-sm fa-fw pe-1"></i>Parameters</strong>
+            {% include "partials/workflows/parameter_list.html" %}
+        </div>
+        <div>
+            <strong class="fs-4"><i class="fa fa-stairs fa-sm fa-fw pe-1"></i>Steps</strong>
+            {% include "partials/workflows/step_list.html" %}
+        </div>
     </div>
 {% endblock content %}

--- a/functionary/ui/templates/core/workflow_detail.html
+++ b/functionary/ui/templates/core/workflow_detail.html
@@ -1,24 +1,33 @@
-{% extends "base_bulma.html" %}
+{% extends "base.html" %}
 {% block content %}
-    <div class="block mt-5">
-        <h1 class="title is-2">
-            <p>
-                <i class="fa fa-diagram-next"></i>
-                <span>{{ workflow.name }}</span>
-                <button class="button is-small is-white has-text-info mr-2 mt-4 fa fa-pencil-alt"
-                        type="button"
-                        title="Edit"
-                        hx-target="body"
-                        hx-swap="beforeend"
-                        hx-get="{% url 'ui:workflow-update' workflow.id %}?id={{ workflow.id }}"/>
-            </p>
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item">
+                <a href="{% url 'ui:workflow-list' %}">Workflow List</a>
+            </li>
+            <li class="breadcrumb-item active" aria-current="page">{{ workflow.name }}</li>
+        </ol>
+    </nav>
+    <div class="hstack gap-3 pt-2 pb-4">
+        <h1>
+            <i class="fa fa-diagram-next"></i>
+            {{ workflow.name }}
         </h1>
+        <div>
+            <i class="fa fa-pencil-alt fa-lg text-info"
+               type="button"
+               title="Edit"
+               hx-target="body"
+               hx-swap="beforeend"
+               hx-get="{% url 'ui:workflow-update' workflow.id %}?id={{ workflow.id }}"></i>
+        </div>
     </div>
-    <div class="block">
-        <span id="desc">{{ workflow.description }}</span>
+    <div class="vstack gap-4 py-2">
+        <div>
+            <strong class="fs-4"><i class="fa fa-newspaper fa-sm fa-fw pe-1"></i>Description</strong>
+            <p id="desc" class="ps-4 py-2">{{ workflow.description }}</p>
+        </div>
+        {% include "partials/workflows/parameter_list.html" %}
+        {% include "partials/workflows/step_list.html" %}
     </div>
-    <hr/>
-    <div class="block">{% include "partials/workflows/parameter_list.html" %}</div>
-    <hr/>
-    <div class="block">{% include "partials/workflows/step_list.html" %}</div>
 {% endblock content %}

--- a/functionary/ui/templates/forms/workflow/parameter_edit.html
+++ b/functionary/ui/templates/forms/workflow/parameter_edit.html
@@ -1,57 +1,42 @@
-{# djlint: off #}
-{% extends "partials/modal_old.html" %}
+{% extends "partials/modal.html" %}
 {% load widget_tweaks %}
-
 {% block modal_title %}
     Workflow Parameter
 {% endblock modal_title %}
-
-{% block form_declaration %}
-    {% if workflowparameter %}
-        <form id="parameter-form" method="post" hx-post="{% url 'ui:workflowparameter-edit' workflow.pk workflowparameter.pk %}" hx-target="#form-modal" hx-swap="outerHTML" enctype="multipart/form-data">
-    {% else %}
-        <form id="parameter-form" method="post" hx-post="{% url 'ui:workflowparameter-create' workflow.pk %}" hx-target="#form-modal" hx-swap="outerHTML" enctype="multipart/form-data">
-    {% endif %}
-    {% csrf_token %}
-{% endblock form_declaration %}
-
 {% block modal_content %}
-    <div class="field">
-        <label class="label" for="{{ form.name.id_for_label }}">{{ form.name.label }}</label>
-        <div class="control">{% render_field form.name class="input" %}</div>
-        <div class="help is-danger">{{ form.name.errors }}</div>
-    </div>
-    <div class="field">
-        <label class="label" for="{{ form.description.id_for_label }}">{{ form.description.label }}</label>
-        <div class="control">{% render_field form.description class="input" %}</div>
-        <div class="help is-danger">{{ form.description.errors }}</div>
-    </div>
-    <div class="columns">
-        <div class="column">
-            <div class="field">
-                <label class="label" for="{{ form.parameter_type.id_for_label }}">{{ form.parameter_type.label }}</label>
-                <div class="control select">{{ form.parameter_type }}</div>
-                <div class="help is-danger">{{ form.parameter_type.errors }}</div>
-            </div>
+    <form id="parameter-form"
+          method="post"
+          hx-post="{% if workflowparameter %}{% url 'ui:workflowparameter-edit' workflow.pk workflowparameter.pk %}{% else %}{% url 'ui:workflowparameter-create' workflow.pk %}{% endif %}"
+          hx-target="#form-modal"
+          hx-swap="outerHTML"
+          enctype="multipart/form-data">
+        {% csrf_token %}
+        <div class="mb-3">
+            <label class="form-label" for="{{ form.name.id_for_label }}">{{ form.name.label }}</label>
+            {% render_field form.name class="form-control" placeholder=form.name.label %}
+            <div class="text-danger">{{ form.name.errors }}</div>
         </div>
-        <div class="column">
-            <div class="field">
-                <label class="label" for="{{ form.required.id_for_label }}">{{ form.required.label }}</label>
-                <div class="control">{{ form.required }}</div>
-            </div>
+        <div class="mb-3">
+            <label class="form-label" for="{{ form.description.id_for_label }}">{{ form.description.label }}</label>
+            {% render_field form.description class="form-control" placeholder=form.description.label %}
+            <div class="text-danger">{{ form.description.errors }}</div>
         </div>
-    </div>
-    <div>
+        <div class="mb-3">
+            <label class="form-label" for="{{ form.parameter_type.id_for_label }}">{{ form.parameter_type.label }}</label>
+            {% render_field form.parameter_type class="form-select" aria-label=form.parameter_type.label %}
+            <div class="text-danger">{{ form.parameter_type.errors }}</div>
+        </div>
+        <div class="mb-3">
+            <label class="form-check-label" for="{{ form.required.id_for_label }}">{{ form.required.label }}</label>
+            {% render_field form.required class="form-check-input" placeholder=form.required.label type="checkbox" %}
+        </div>
         <input type="hidden" name="workflow" value="{{ workflow.id }}"/>
-    </div>
-    {{ form.non_field_errors }}
+        {{ form.non_field_errors }}
+    </form>
 {% endblock modal_content %}
-
 {% block modal_footer %}
-    <button class="button" type="submit" value="Save">Save</button>
+    <button class="btn btn-primary"
+            type="submit"
+            form="parameter-form"
+            value="Save">Save</button>
 {% endblock modal_footer %}
-
-{% block form_end %}
-</form>
-{% endblock form_end %}
-{# djlint: on #}

--- a/functionary/ui/templates/forms/workflow/step_edit.html
+++ b/functionary/ui/templates/forms/workflow/step_edit.html
@@ -20,10 +20,8 @@
             {% render_field form.function class="form-select" aria-label=form.function.label %}
             <div class="text-danger">{{ form.function.errors }}</div>
         </div>
+        <div class="mb-3"  id="function-parameters">{{ parameter_form }}</div>
         <div>{{ form.non_field_errors }}</div>
-        <div class="field">
-            <div id="function-parameters">{{ parameter_form }}</div>
-        </div>
         <div>{{ form.workflow }}</div>
         <div>{{ form.next }}</div>
     </form>

--- a/functionary/ui/templates/forms/workflow/step_edit.html
+++ b/functionary/ui/templates/forms/workflow/step_edit.html
@@ -1,43 +1,33 @@
-{# djlint: off #}
-{% extends "partials/modal_old.html" %}
+{% extends "partials/modal.html" %}
 {% load widget_tweaks %}
-
 {% block modal_title %}
     Workflow Step
 {% endblock modal_title %}
-
-{% block form_declaration %}
-    {% if workflowstep %}
-        <form id="step-form" method="post" hx-post="{% url 'ui:workflowstep-edit' view.kwargs.workflow_pk workflowstep.pk %}" hx-target="#form-modal" hx-swap="outerHTML" enctype="multipart/form-data">
-    {% else %}
-        <form id="step-form" method="post" hx-post="{% url 'ui:workflowstep-create' view.kwargs.workflow_pk %}" hx-target="#form-modal" hx-swap="outerHTML" enctype="multipart/form-data">
-    {% endif %}
-{% endblock form_declaration %}
-
 {% block modal_content %}
-    <div class="field">
-        <label class="label" for="{{ form.name.id_for_label }}">{{ form.name.label }}</label>
-        <div class="control">{% render_field form.name class="input" %}</div>
+    <form id="step-form"
+          method="post"
+          hx-post="{% if workflowstep %}{% url 'ui:workflowstep-edit' view.kwargs.workflow_pk workflowstep.pk %}{% else %}{% url 'ui:workflowstep-create' view.kwargs.workflow_pk %}{% endif %}"
+          hx-target="#form-modal"
+          hx-swap="outerHTML"
+          enctype="multipart/form-data">
+        <div class="mb-3">
+            <label class="form-label" for="{{ form.name.id_for_label }}">{{ form.name.label }}</label>
+            {% render_field form.name class="form-control" placeholder=form.name.label %}
+            <div class="text-danger">{{ form.name.errors }}</div>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="{{ form.function.id_for_label }}">{{ form.function.label }}</label>
+            {% render_field form.function class="form-select" aria-label=form.function.label %}
+            <div class="text-danger">{{ form.function.errors }}</div>
+        </div>
         <div>{{ form.non_field_errors }}</div>
-        <div>{{ form.name.errors }}</div>
-    </div>
-    <div class="field">
-        <label class="label" for="{{ form.function.id_for_label }}">{{ form.function.label }}</label>
-        <div class="control select">{{ form.function }}</div>
-        <div>{{ form.function.errors }}</div>
-    </div>
-    <div class="field">
-        <div id="function-parameters">{{ parameter_form }}</div>
-    </div>
-    <div>{{form.workflow}}</div>
-    <div>{{form.next}}</div>
-{% endblock modal_content %}
-
-{% block modal_footer %}
-    <button class="button" type="submit" value="Save">Save</button>
-{% endblock modal_footer %}
-
-{% block form_end %}
+        <div class="field">
+            <div id="function-parameters">{{ parameter_form }}</div>
+        </div>
+        <div>{{ form.workflow }}</div>
+        <div>{{ form.next }}</div>
     </form>
-{% endblock form_end %}
-{# djlint: on #}
+{% endblock modal_content %}
+{% block modal_footer %}
+    <button class="btn btn-primary" type="submit" form="step-form" value="Save">Save</button>
+{% endblock modal_footer %}

--- a/functionary/ui/templates/forms/workflow/step_edit.html
+++ b/functionary/ui/templates/forms/workflow/step_edit.html
@@ -20,7 +20,7 @@
             {% render_field form.function class="form-select" aria-label=form.function.label %}
             <div class="text-danger">{{ form.function.errors }}</div>
         </div>
-        <div class="mb-3"  id="function-parameters">{{ parameter_form }}</div>
+        <div class="mb-3" id="function-parameters">{{ parameter_form }}</div>
         <div>{{ form.non_field_errors }}</div>
         <div>{{ form.workflow }}</div>
         <div>{{ form.next }}</div>

--- a/functionary/ui/templates/forms/workflow/workflow_edit.html
+++ b/functionary/ui/templates/forms/workflow/workflow_edit.html
@@ -10,12 +10,12 @@
           hx-target="#form-modal"
           hx-swap="outerHTML">
         {% csrf_token %}
-        <div class="mb-1">
+        <div class="mb-3">
             <label for="{{ form.name.id_for_label }}" class="form-label">{{ form.name.label }}</label>
             {% render_field form.name class="form-control" placeholder=form.name.label %}
         </div>
         {{ form.name.errors }}
-        <div class="mb-1">
+        <div class="mb-3">
             <label for="{{ form.description.id_for_label }}" class="form-label">{{ form.description.label }}</label>
             {% render_field form.description class="form-control" placeholder=form.description.label %}
         </div>
@@ -27,7 +27,7 @@
     </form>
 {% endblock modal_content %}
 {% block modal_footer %}
-    <button class="btn btn-success" type="submit" form="workflow-form">
+    <button class="btn btn-primary" type="submit" form="workflow-form">
         {% if workflow %}
             Save
         {% else %}

--- a/functionary/ui/templates/partials/modal.html
+++ b/functionary/ui/templates/partials/modal.html
@@ -21,8 +21,6 @@
                             onclick="return document.querySelector('#modal-group').remove();">
                     </button>
                 </div>
-                {% block form_declaration %}
-                {% endblock form_declaration %}
                 <div class="modal-body">
                     <p class="lead">
                         {% block modal_description %}

--- a/functionary/ui/templates/partials/table.html
+++ b/functionary/ui/templates/partials/table.html
@@ -1,3 +1,3 @@
 {% load django_tables2 %}
 {% load widget_tweaks %}
-<div id="table-list-block" class="table-container">{% render_table table 'django_tables2/bootstrap5.html' %}</div>
+<div id="table-list-block">{% render_table table 'django_tables2/bootstrap5.html' %}</div>

--- a/functionary/ui/templates/partials/workflows/parameter_list.html
+++ b/functionary/ui/templates/partials/workflows/parameter_list.html
@@ -1,6 +1,5 @@
-<strong class="fs-4"><i class="fa fa-list fa-sm fa-fw pe-1"></i>Parameters</strong>
-<div class="ps-4 py-2">
-    <div id="tableParameter" class="table-container">
+<div id="tableParameter" class="ps-4 py-2">
+    <div class="table-container">
         <table class="table table-striped table-sm">
             <thead>
                 <tr>

--- a/functionary/ui/templates/partials/workflows/parameter_list.html
+++ b/functionary/ui/templates/partials/workflows/parameter_list.html
@@ -7,7 +7,7 @@
                     <th scope="col">Name</th>
                     <th scope="col">Description</th>
                     <th scope="col">Type</th>
-                    <th scope="col">Required</th>
+                    <th scope="col" class="text-center">Required</th>
                     <th scope="col"></th>
                 </tr>
             </thead>

--- a/functionary/ui/templates/partials/workflows/parameter_list.html
+++ b/functionary/ui/templates/partials/workflows/parameter_list.html
@@ -1,7 +1,7 @@
 <strong class="fs-4"><i class="fa fa-list fa-sm fa-fw pe-1"></i>Parameters</strong>
 <div class="ps-4 py-2">
     <div id="tableParameter" class="table-container">
-        <table class="table table-striped">
+        <table class="table table-striped table-sm">
             <thead>
                 <tr>
                     <th scope="col">Name</th>

--- a/functionary/ui/templates/partials/workflows/parameter_list.html
+++ b/functionary/ui/templates/partials/workflows/parameter_list.html
@@ -1,43 +1,47 @@
-<h2 class="title is-4">Parameters</h2>
-<table class="table is-striped">
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Description</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody id="parameters">
-        {% for parameter in workflow.parameters.all %}
-            <tr>
-                <td>{{ parameter.name }}</td>
-                <td>{{ parameter.description }}</td>
-                <td>{{ parameter.parameter_type }}</td>
-                <td class="has-text-centered">
-                    {% if parameter.required %}<i class="fa fa-check"/>{% endif %}
-                </td>
-                <td hx-target="closest tr" hx-swap="outerHTML">
-                    <button class="button is-small mr-2 is-white has-text-info fa fa-pencil-alt"
-                            type="button"
-                            title="Edit"
-                            hx-target="body"
-                            hx-swap="beforeend"
-                            hx-get="{% url 'ui:workflowparameter-edit' workflow.pk parameter.pk %}"/>
-                    <button class="button is-small is-white has-text-danger fa fa-trash"
-                            type="button"
-                            title="Delete"
-                            hx-delete="{% url 'ui:workflowparameter-delete' workflow.pk parameter.pk %}"/>
-                </td>
-            </tr>
-        {% endfor %}
-    </tbody>
-</table>
-<button class="button is-small"
-        type="button"
-        hx-target="body"
-        hx-swap="beforeend"
-        hx-get="{% url 'ui:workflowparameter-create' workflow.pk %}">
-    <span class="mr-2">Add</span><span class="fa fa-plus"/>
-</button>
+<strong class="fs-4"><i class="fa fa-list fa-sm fa-fw pe-1"></i>Parameters</strong>
+<div class="ps-4 py-2">
+    <div id="tableParameter" class="table-container">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Description</th>
+                    <th scope="col">Type</th>
+                    <th scope="col">Required</th>
+                    <th scope="col"></th>
+                </tr>
+            </thead>
+            <tbody id="parameters">
+                {% for parameter in workflow.parameters.all %}
+                    <tr>
+                        <td>{{ parameter.name }}</td>
+                        <td>{{ parameter.description }}</td>
+                        <td>{{ parameter.parameter_type }}</td>
+                        <td class="text-center">
+                            {% if parameter.required %}<i class="fa fa-check"/>{% endif %}
+                        </td>
+                        <td hx-target="closest tr" hx-swap="outerHTML">
+                            <button class="btn btn-small text-info fa fa-pencil-alt"
+                                    type="button"
+                                    title="Edit"
+                                    hx-target="body"
+                                    hx-swap="beforeend"
+                                    hx-get="{% url 'ui:workflowparameter-edit' workflow.pk parameter.pk %}"/>
+                            <button class="btn btn-small text-danger fa fa-trash"
+                                    type="button"
+                                    title="Delete"
+                                    hx-delete="{% url 'ui:workflowparameter-delete' workflow.pk parameter.pk %}"/>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <button class="btn btn-primary fa-plus"
+            type="button"
+            hx-target="body"
+            hx-swap="beforeend"
+            hx-get="{% url 'ui:workflowparameter-create' workflow.pk %}">
+        Add
+    </button>
+</div>

--- a/functionary/ui/templates/partials/workflows/step_list.html
+++ b/functionary/ui/templates/partials/workflows/step_list.html
@@ -24,7 +24,7 @@
                                             {% if previous is None %}hidden{% endif %}
                                             hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
                                             hx-target="#workflow-steps"
-                                            hx-swap="OuterHTML"
+                                            hx-swap="outerHTML"
                                             hx-vals='{"next": "{{ previous.id }}"}'/>
                                     <button class="btn btn-small text-primary fa fa-chevron-down border-0"
                                             id="step-{{ step.id }}-move-down"
@@ -33,7 +33,7 @@
                                             {% if next is None %}hidden{% endif %}
                                             hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
                                             hx-target="#workflow-steps"
-                                            hx-swap="OuterHTML"
+                                            hx-swap="outerHTML"
                                             hx-vals='{"next": "{{ next.next.id }}"}'/>
                                 </div>
                             {% endwith %}

--- a/functionary/ui/templates/partials/workflows/step_list.html
+++ b/functionary/ui/templates/partials/workflows/step_list.html
@@ -1,7 +1,5 @@
-<strong class="fs-4"><i class="fa fa-stairs fa-sm fa-fw pe-1"></i>Steps</strong>
-<div id="workflow-steps" class="ps-4 py-2" hx-swap-oob="true">
-    <!--TODO: A table is not really suitable for this data. This is just a
-    placeholder to demonstrate the functionality-->
+<div id="workflow-steps" class="ps-4 py-2">
+    <!--TODO: A table is not really suitable for this data. This is a placeholder-->
     <div id="tableSteps" class="table-container">
         <table class="table table-striped table-sm">
             <thead>
@@ -20,6 +18,7 @@
                             {% with previous=step.previous next=step.next %}
                                 <div class="d-flex {% if previous is None %}justify-content-end{% elif next is None %}justify-content-start{% else %}justify-content-between{% endif %}">
                                     <button class="btn btn-small text-primary fa fa-chevron-up border-0"
+                                            id="step-{{ step.id }}-move-up"
                                             type="button"
                                             title="Move Step Up"
                                             {% if previous is None %}hidden{% endif %}
@@ -28,6 +27,7 @@
                                             hx-swap="OuterHTML"
                                             hx-vals='{"next": "{{ previous.id }}"}'/>
                                     <button class="btn btn-small text-primary fa fa-chevron-down border-0"
+                                            id="step-{{ step.id }}-move-down"
                                             type="button"
                                             title="Move Step Down"
                                             {% if next is None %}hidden{% endif %}

--- a/functionary/ui/templates/partials/workflows/step_list.html
+++ b/functionary/ui/templates/partials/workflows/step_list.html
@@ -3,7 +3,7 @@
     <!--TODO: A table is not really suitable for this data. This is just a
     placeholder to demonstrate the functionality-->
     <div id="tableSteps" class="table-container">
-        <table class="table table-striped">
+        <table class="table table-striped table-sm">
             <thead>
                 <tr>
                     <th scope="col"></th>
@@ -16,26 +16,28 @@
             <tbody id="steps">
                 {% for step in workflow.ordered_steps %}
                     <tr id="step-{{ step.id }}">
-                        {% with previous=step.previous next=step.next %}
-                            <td class="d-flex {% if previous is None %}justify-content-end{% elif next is None %}justify-content-start{% else %}justify-content-between{% endif %}">
-                                <button class="btn btn-small text-primary fa fa-chevron-up border-0"
-                                        type="button"
-                                        title="Move Step Up"
-                                        {% if previous is None %}hidden{% endif %}
-                                        hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
-                                        hx-target="#workflow-steps"
-                                        hx-swap="OuterHTML"
-                                        hx-vals='{"next": "{{ previous.id }}"}'/>
-                                <button class="btn btn-small text-primary fa fa-chevron-down border-0"
-                                        type="button"
-                                        title="Move Step Down"
-                                        {% if next is None %}hidden{% endif %}
-                                        hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
-                                        hx-target="#workflow-steps"
-                                        hx-swap="OuterHTML"
-                                        hx-vals='{"next": "{{ next.next.id }}"}'/>
-                            </td>
-                        {% endwith %}
+                        <td>
+                            {% with previous=step.previous next=step.next %}
+                                <div class="d-flex {% if previous is None %}justify-content-end{% elif next is None %}justify-content-start{% else %}justify-content-between{% endif %}">
+                                    <button class="btn btn-small text-primary fa fa-chevron-up border-0"
+                                            type="button"
+                                            title="Move Step Up"
+                                            {% if previous is None %}hidden{% endif %}
+                                            hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
+                                            hx-target="#workflow-steps"
+                                            hx-swap="OuterHTML"
+                                            hx-vals='{"next": "{{ previous.id }}"}'/>
+                                    <button class="btn btn-small text-primary fa fa-chevron-down border-0"
+                                            type="button"
+                                            title="Move Step Down"
+                                            {% if next is None %}hidden{% endif %}
+                                            hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
+                                            hx-target="#workflow-steps"
+                                            hx-swap="OuterHTML"
+                                            hx-vals='{"next": "{{ next.next.id }}"}'/>
+                                </div>
+                            {% endwith %}
+                        </td>
                         <td>{{ step.name }}</td>
                         <td>{{ step.function }}</td>
                         <td class="json-container">{{ step.parameter_template }}</td>

--- a/functionary/ui/templates/partials/workflows/step_list.html
+++ b/functionary/ui/templates/partials/workflows/step_list.html
@@ -1,5 +1,5 @@
 <strong class="fs-4"><i class="fa fa-stairs fa-sm fa-fw pe-1"></i>Steps</strong>
-<div id="workflow-steps" class="ps-4 py-2">
+<div id="workflow-steps" class="ps-4 py-2" hx-swap-oob="true">
     <!--TODO: A table is not really suitable for this data. This is just a
     placeholder to demonstrate the functionality-->
     <div id="tableSteps" class="table-container">
@@ -16,28 +16,26 @@
             <tbody id="steps">
                 {% for step in workflow.ordered_steps %}
                     <tr id="step-{{ step.id }}">
-                        <td>
-                            {% with previous=step.previous next=step.next %}
-                                {% if previous is not None %}
-                                    <button class="btn btn-small text-info fa fa-chevron-up"
-                                            type="button"
-                                            title="Move Step Up"
-                                            hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
-                                            hx-target="#workflow-steps"
-                                            hx-swap="OuterHTML"
-                                            hx-vals='{"next": "{{ previous.id }}"}'/>
-                                {% endif %}
-                                {% if next is not None %}
-                                    <button class="btn btn-small text-info fa fa-chevron-down"
-                                            type="button"
-                                            title="Move Step Down"
-                                            hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
-                                            hx-target="#workflow-steps"
-                                            hx-swap="OuterHTML"
-                                            hx-vals='{"next": "{{ next.next.id }}"}'/>
-                                {% endif %}
-                            {% endwith %}
-                        </td>
+                        {% with previous=step.previous next=step.next %}
+                            <td class="d-flex {% if previous is None %}justify-content-end{% elif next is None %}justify-content-start{% else %}justify-content-between{% endif %}">
+                                <button class="btn btn-small text-primary fa fa-chevron-up border-0"
+                                        type="button"
+                                        title="Move Step Up"
+                                        {% if previous is None %}hidden{% endif %}
+                                        hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
+                                        hx-target="#workflow-steps"
+                                        hx-swap="OuterHTML"
+                                        hx-vals='{"next": "{{ previous.id }}"}'/>
+                                <button class="btn btn-small text-primary fa fa-chevron-down border-0"
+                                        type="button"
+                                        title="Move Step Down"
+                                        {% if next is None %}hidden{% endif %}
+                                        hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
+                                        hx-target="#workflow-steps"
+                                        hx-swap="OuterHTML"
+                                        hx-vals='{"next": "{{ next.next.id }}"}'/>
+                            </td>
+                        {% endwith %}
                         <td>{{ step.name }}</td>
                         <td>{{ step.function }}</td>
                         <td class="json-container">{{ step.parameter_template }}</td>

--- a/functionary/ui/templates/partials/workflows/step_list.html
+++ b/functionary/ui/templates/partials/workflows/step_list.html
@@ -1,84 +1,77 @@
-<div id="workflow-steps">
-    <h2 class="title is-4">Steps</h2>
+<strong class="fs-4"><i class="fa fa-stairs fa-sm fa-fw pe-1"></i>Steps</strong>
+<div id="workflow-steps" class="ps-4 py-2">
     <!--TODO: A table is not really suitable for this data. This is just a
     placeholder to demonstrate the functionality-->
-    <table class="table is-striped">
-        <thead>
-            <tr>
-                <th></th>
-                <th></th>
-                <th>Name</th>
-                <th>Function</th>
-                <th>Parameters</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody id="steps">
-            {% for step in workflow.ordered_steps %}
-                <tr id="step-{{ step.id }}">
-                    <td>
-                        {% with previous=step.previous %}
-                            {% if previous is not None %}
-                                <form id="step-{{ step.id }}-move-up"
-                                      method="post"
-                                      hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
-                                      hx-target="#workflow-steps"
-                                      hx-swap="OuterHTML">
-                                    <input type="hidden" name="next" value="{{ previous.id }}"/>
-                                    <button class="button is-small is-white has-text-info fa fa-chevron-up"
-                                            type="submit"
-                                            title="Move Step Up"/>
-                                </form>
-                            {% endif %}
-                        {% endwith %}
-                    </td>
-                    <td>
-                        {% if step.next is not None %}
-                            <form id="step-{{ step.id }}-move-down"
-                                  method="post"
-                                  hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
-                                  hx-target="#workflow-steps"
-                                  hx-swap="OuterHTML">
-                                <input type="hidden" name="next" value="{{ step.next.next.id }}"/>
-                                <button class="button is-small is-white has-text-info fa fa-chevron-down"
-                                        type="submit"
-                                        title="Move Step Down"/>
-                            </form>
-                        {% endif %}
-                    </td>
-                    <td>{{ step.name }}</td>
-                    <td>{{ step.function }}</td>
-                    <td class="json-container">{{ step.parameter_template }}</td>
-                    <td>
-                        <button class="button is-small mr-2 is-white has-text-success fa fa-plus"
-                                type="button"
-                                title="Add Step Below"
-                                hx-target="body"
-                                hx-swap="beforeend"
-                                hx-get="{% url 'ui:workflowstep-create' workflow.pk %}"
-                                hx-vals='{"next": "{{ step.next.id }}"}'/>
-                        <button class="button is-small mr-2 is-white has-text-info fa fa-pencil-alt"
-                                type="button"
-                                title="Edit"
-                                hx-target="body"
-                                hx-swap="beforeend"
-                                hx-get="{% url 'ui:workflowstep-edit' workflow.pk step.pk %}"/>
-                        <button class="button is-small is-white has-text-danger fa fa-trash"
-                                type="button"
-                                title="Delete"
-                                hx-target="#workflow-steps"
-                                hx-swap="outerHTML"
-                                hx-delete="{% url 'ui:workflowstep-delete' workflow.pk step.pk %}"/>
-                    </td>
+    <div id="tableSteps" class="table-container">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th scope="col"></th>
+                    <th scope="col">Name</th>
+                    <th scope="col">Function</th>
+                    <th scope="col">Parameters</th>
+                    <th scope="col"></th>
                 </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    <button class="button is-small"
+            </thead>
+            <tbody id="steps">
+                {% for step in workflow.ordered_steps %}
+                    <tr id="step-{{ step.id }}">
+                        <td>
+                            {% with previous=step.previous next=step.next %}
+                                {% if previous is not None %}
+                                    <button class="btn btn-small text-info fa fa-chevron-up"
+                                            type="button"
+                                            title="Move Step Up"
+                                            hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
+                                            hx-target="#workflow-steps"
+                                            hx-swap="OuterHTML"
+                                            hx-vals='{"next": "{{ previous.id }}"}'/>
+                                {% endif %}
+                                {% if next is not None %}
+                                    <button class="btn btn-small text-info fa fa-chevron-down"
+                                            type="button"
+                                            title="Move Step Down"
+                                            hx-post="{% url 'ui:workflowstep-move' workflow.pk step.pk %}"
+                                            hx-target="#workflow-steps"
+                                            hx-swap="OuterHTML"
+                                            hx-vals='{"next": "{{ next.next.id }}"}'/>
+                                {% endif %}
+                            {% endwith %}
+                        </td>
+                        <td>{{ step.name }}</td>
+                        <td>{{ step.function }}</td>
+                        <td class="json-container">{{ step.parameter_template }}</td>
+                        <td>
+                            <button class="btn btn-small text-success fa fa-plus"
+                                    type="button"
+                                    title="Add Step Below"
+                                    hx-target="body"
+                                    hx-swap="beforeend"
+                                    hx-get="{% url 'ui:workflowstep-create' workflow.pk %}"
+                                    hx-vals='{"next": "{{ step.next.id }}"}'/>
+                            <button class="btn btn-small text-info fa fa-pencil-alt"
+                                    type="button"
+                                    title="Edit"
+                                    hx-target="body"
+                                    hx-swap="beforeend"
+                                    hx-get="{% url 'ui:workflowstep-edit' workflow.pk step.pk %}"/>
+                            <button class="btn btn-small text-danger fa fa-trash"
+                                    type="button"
+                                    title="Delete"
+                                    hx-target="#workflow-steps"
+                                    hx-swap="outerHTML"
+                                    hx-delete="{% url 'ui:workflowstep-delete' workflow.pk step.pk %}"/>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <button class="btn btn-primary fa-plus"
             type="button"
             hx-target="body"
             hx-swap="beforeend"
             hx-get="{% url 'ui:workflowstep-create' workflow.pk %}">
-        <span class="mr-2">Add</span><span class="fa fa-plus"/>
+        Add
     </button>
 </div>

--- a/functionary/ui/views/workflow/detail.py
+++ b/functionary/ui/views/workflow/detail.py
@@ -3,6 +3,6 @@ from ui.views.generic import PermissionedDetailView
 
 
 class WorkflowDetailView(PermissionedDetailView):
-    "Detail view for the Workflow model"
+    """Detail view for the Workflow model"""
 
     model = Workflow


### PR DESCRIPTION
Does not close ticket, still further work to do.

Converts Workflow detail page into bootstrap. All functionality on the page should work and by styled, including modals. Step table rows can be sorted with up/down arrows. Made a note on the UI ToDo to look into drag/drop as alternate for table row arrows.

Added missing breadcrumbs to Workflow Detail page. A little code cleanup / remove necessary classes.

Main title icon seemed excessively large - decreased size. Changed a few buttons to `primary` from `success` color.