### PR TITLE
#222 - Added error handling to package yaml extraction

### DIFF
--- a/functionary/builder/api/v1/serializers/package_definition.py
+++ b/functionary/builder/api/v1/serializers/package_definition.py
@@ -58,7 +58,7 @@ class PackageDefinitionSerializer(serializers.Serializer):
     environment = serializers.DictField(
         child=serializers.CharField(), required=False, read_only=True
     )
-    functions = FunctionSerializer(many=True)
+    functions = FunctionSerializer(many=True, allow_empty=False)
 
 
 class PackageDefinitionWithVersionSerializer(serializers.Serializer):

--- a/functionary/builder/api/v1/urls.py
+++ b/functionary/builder/api/v1/urls.py
@@ -8,5 +8,5 @@ router.register(r"builds", views.BuildViewSet)
 
 urlpatterns = [
     path("", include(router.urls)),
-    path("publish", views.PublishView.as_view()),
+    path("publish", views.PublishView.as_view(), name="publish"),
 ]

--- a/functionary/builder/api/v1/views/publish.py
+++ b/functionary/builder/api/v1/views/publish.py
@@ -52,8 +52,10 @@ class PublishView(APIView, EnvironmentViewMixin):
         # TO-DO: put invalid package yaml class here
         try:
             package_yaml = extract_package_definition(package_contents_blob)
-        except InvalidPackage:
-            raise InvalidPackage("Could not extract package.yaml from package tarball")
+        except InvalidPackage as err:
+            raise InvalidPackage(
+                f"Failed extracting package.yaml from package tarball: {err}"
+            )
 
         # If the package definition schema changes at any point, this would need to
         # identify the correct serializer based on the package_definition_version

--- a/functionary/builder/tests/test_utils.py
+++ b/functionary/builder/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+from yaml import YAMLError
 
 from builder import utils
 from core.models import Function, Package, Team, User
@@ -13,6 +14,11 @@ def user():
 @pytest.fixture
 def team():
     return Team.objects.create(name="team")
+
+
+@pytest.fixture
+def package_contents():
+    return bytes("example package contents", encoding="utf-8")
 
 
 @pytest.fixture
@@ -119,3 +125,37 @@ def test_delete_removed_function_parameters(function1):
 
     assert function1.parameters.count() == 1
     assert function1.parameters.filter(name="param1").exists()
+
+
+def test_invalid_package_yaml(mocker, package_contents):
+    class TarFile:
+        def close():
+            return
+
+    def mock_tarfile(_bytes):
+        return TarFile
+
+    def mock_missing_package_yaml(_package_yaml):
+        raise KeyError("missing package yaml")
+
+    def mock_invalid_package_yaml(_package_yaml):
+        raise YAMLError
+
+    def mock_invalid_package(_package_yaml):
+        raise utils.InvalidPackage
+
+    mocker.patch("builder.utils._get_tarfile", mock_tarfile)
+    mocker.patch("builder.utils._extract_package_definition", mock_missing_package_yaml)
+
+    with pytest.raises(utils.InvalidPackage):
+        utils.extract_package_definition(package_contents)
+
+    mocker.patch("builder.utils._extract_package_definition", mock_invalid_package_yaml)
+
+    with pytest.raises(utils.InvalidPackage):
+        utils.extract_package_definition(package_contents)
+
+    mocker.patch("builder.utils._extract_package_definition", mock_invalid_package)
+
+    with pytest.raises(utils.InvalidPackage):
+        utils.extract_package_definition(package_contents)

--- a/functionary/builder/tests/views/test_publish.py
+++ b/functionary/builder/tests/views/test_publish.py
@@ -1,0 +1,53 @@
+import io
+import tarfile
+
+import pytest
+from django.test.client import MULTIPART_CONTENT
+from django.urls import reverse
+
+from core.models import Environment, Team
+
+
+@pytest.fixture
+def environment() -> Environment:
+    team = Team.objects.create(name="team")
+    return team.environments.get()
+
+
+@pytest.fixture
+def request_headers(environment: Environment) -> dict:
+    return {"HTTP_X_ENVIRONMENT_ID": str(environment.id)}
+
+
+@pytest.fixture
+def package_tarball_with_malformed_yaml() -> io.BytesIO:
+    malformed_yaml = "somelist:\n"
+    malformed_yaml += "  - entry\n"
+    malformed_yaml += "- underindented entry"
+
+    package_tarball = io.BytesIO()
+
+    tarinfo = tarfile.TarInfo(name="package.yaml")
+    tarinfo.size = len(malformed_yaml)
+
+    with tarfile.open(fileobj=package_tarball, mode="w") as tarball:
+        tarball.addfile(tarinfo, io.BytesIO(malformed_yaml.encode()))
+
+    package_tarball.seek(0)
+
+    return package_tarball
+
+
+def test_publish_returns_400_for_malformed_yaml(
+    admin_client, request_headers, package_tarball_with_malformed_yaml
+):
+    """publish should return a 400 if the package.yaml is malformed"""
+    url = reverse("publish")
+
+    input = {"package_contents": package_tarball_with_malformed_yaml}
+
+    response = admin_client.post(
+        url, data=input, content_type=MULTIPART_CONTENT, **request_headers
+    )
+
+    assert response.status_code == 400

--- a/functionary/builder/utils.py
+++ b/functionary/builder/utils.py
@@ -8,12 +8,13 @@ from typing import List
 from uuid import UUID
 
 import docker
-import yaml
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.db import transaction
 from django.template.loader import get_template
 from docker.errors import APIError, BuildError, DockerException
+from yaml import YAMLError, safe_load
+from yaml.parser import ParserError
 
 from core.models import Environment, Function, FunctionParameter, Package, User
 
@@ -33,34 +34,49 @@ def extract_package_definition(package_contents: bytes) -> dict:
 
     Returns:
         The package definition yaml loaded as a dict
+
+    Raises:
+        InvalidPackage: Raised whenever an error is encountered while extracting
+            package contents from the package.yaml in the tarball
     """
     package_contents_io = io.BytesIO(package_contents)
 
     try:
         tarball = tarfile.open(fileobj=package_contents_io, mode="r")
+        package_definition = _extract_package_definition(tarball)
+        return package_definition
     except tarfile.ReadError:
         raise InvalidPackage(
             "Could not untar package file. Make sure it is a valid gzipped tarball."
         )
-
-    def close_files():
-        package_contents_io.close()
-        tarball.close()
-
-    try:
-        package_definition_io = tarball.extractfile("package.yaml")
     except KeyError:
-        close_files()
         raise InvalidPackage("package.yaml not found")
+    except (InvalidPackage, YAMLError, ParserError):
+        raise InvalidPackage("package.yaml is invalid YAML")
+    finally:
+        tarball.close()
+        package_contents_io.close()
 
-    if package_definition_io is None:
-        close_files()
-        raise InvalidPackage("package.yaml found, but is not a regular file")
 
-    package_definition = yaml.safe_load(package_definition_io.read())
-    close_files()
+def _extract_package_definition(tarball: tarfile.TarFile) -> dict:
+    """Extract the package definition from given tarfile
 
-    return package_definition
+    Args:
+        tarball: The opened tarfile in read mode
+
+    Returns:
+        package_contents: A dictionary representation of the package yaml
+
+    Raises:
+        InvalidPackage: Raised when the package.yaml is not a regular file
+        ParseError: Raised when there is an error parsing the package yaml
+        YAMLError: Raised when the YAML parser encounters an error condition
+    """
+    package_yaml = tarball.extractfile("package.yaml")
+    if not package_yaml:
+        raise InvalidPackage("package.yaml found, but it is not a regular file.")
+
+    return safe_load(package_yaml.read())
 
 
 def initiate_build(

--- a/functionary/builder/utils.py
+++ b/functionary/builder/utils.py
@@ -40,6 +40,7 @@ def extract_package_definition(package_contents: bytes) -> dict:
             package contents from the package.yaml in the tarball
     """
     package_contents_io = io.BytesIO(package_contents)
+    tarfile = None
 
     try:
         tarfile = _get_tarfile(package_contents_io)
@@ -53,8 +54,12 @@ def extract_package_definition(package_contents: bytes) -> dict:
         raise InvalidPackage("package.yaml not found")
     except (InvalidPackage, YAMLError):
         raise InvalidPackage("package.yaml is invalid YAML")
+    except Exception as err:
+        logger.error(f"Failed extracting package definition: {err}")
+        raise InvalidPackage("failed to extract package definition")
     finally:
-        tarfile.close()
+        if tarfile:
+            tarfile.close()
         package_contents_io.close()
 
 


### PR DESCRIPTION
Closes #222 

## Introduced Changes
- Added more `try`/`excepts` to parts of the `extract_package_definition` method in the builder
  - Handle the YAML parse issues to prevent `500` error. Now returns a `400`

## Testing
Create a new package with a malformed package.yaml:
```yaml
version: 1.0
package:
  name: "invalid"
  display_name: Functionality Demo
  summary: Provides functions that demo / test various available features
  language: "python"
  functions:
    - name: output_json
      summary: Demonstrates JSON output rendering
      display_name: Output JSON
      description:
        'Takes in a JSON blob and then simply returns that to demonstrate how
        the JSON rendering works in the UI. To see table rendering, the input
        should be a list formatted something like: [ { "param1": "value1",
        "param2": "value2" }, { "param1": "value3", "param2": "value4" } ]'
      parameters:
        - name: input
          summary: The JSON blob to render
          type: json
          required: true
      return_type: json
  - name: output_text
    summary: Demonstrates text output rendering
    display_name: Output Text
    description:
      Takes in a string and then simply returns that to demonstrate how string
      results rendering works in the UI. CSV formatted text will provide the
      option to be rendered as a table.
    parameters:
      - name: input
        summary: The text to render
        type: text
        required: true
    return_type: string
```

## Notes
In your `package.yaml`, if `.package.functions` is just an empty dictionary, no exception is raised. We probably should define a schema for the packages once we finalize all of the fields, such that incorrect field types are handles. This will also help combat some of the auto type casting YAML will perform, such as turning `yes` into a boolean in fields that are meant to be strings.