### PR TITLE
Added ability to refresh the login token.

### DIFF
--- a/functionary/ui/templates/account/details.html
+++ b/functionary/ui/templates/account/details.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% load static %}
+{% block extra_style %}
+    <link rel="stylesheet" href="{% static 'css/brands.css' %}" />
+{% endblock extra_style %}
+{% block content %}
+    {% include "partials/socialaccount/connections.html" %}
+    <br/>
+    {% include "partials/token.html" %}
+{% endblock content %}

--- a/functionary/ui/templates/base.html
+++ b/functionary/ui/templates/base.html
@@ -91,7 +91,7 @@
                             <hr/>
                             <nav class="navbar navbar-dark nav-pills flex-column mb-2 pe-md-5">
                                 <div class="navbar-nav">
-                                    <a class="nav-link px-0" href="{% url 'socialaccount_connections' %}">
+                                    <a class="nav-link px-0" href="{% url 'ui:account-detail' %}">
                                         <i class="fa fa-lg fa-user fa-fw"></i>
                                         <span class="ms-1 d-none d-md-inline">{{ user }}</span>
                                     </a>

--- a/functionary/ui/templates/partials/socialaccount/connections.html
+++ b/functionary/ui/templates/partials/socialaccount/connections.html
@@ -2,66 +2,68 @@
 {% load social_helper %}
 <div id="social_account_connections">
     <strong class="fs-4"><i class="fa fa-id-card fa-sm fa-fw pe-1"></i>Account Connections</strong>
-    {% configured_providers as socialaccount_providers %}
-    {% if not socialaccount_providers %}
-        <p>No third party accounts available to connect</p>
-    {% else %}
-        <p>Manage third party account login connections here.</p>
-        <div class="row flex-nowrap">
-            <div class="col-9">
-                <form hx-post="{% url 'ui:account-disconnect-social' %}">
-                    {% csrf_token %}
-                    {% if form.non_field_errors %}<div id="errorMsg">{{ form.non_field_errors }}</div>{% endif %}
-                    <table class="table table-sm table-striped">
-                        <thead>
-                            <tr>
-                                <th scope="col">Provider</th>
-                                <th scope="col">Account</th>
-                                <th scope="col"></th>
-                            </tr>
-                        </thead>
-                        <tbody class="table-group-divider">
-                            {% for provider_pair in socialaccount_providers %}
-                                {% find_account provider_pair.provider.id as existing_account %}
+    <div class="ps-4">
+        <div class="col-9 py-1">
+            {% configured_providers as socialaccount_providers %}
+            {% if not socialaccount_providers %}
+                <p>No third party accounts available to connect</p>
+            {% else %}
+                <p>Manage third party account login connections here.</p>
+                <div class="row flex-nowrap">
+                    <form hx-post="{% url 'ui:account-disconnect-social' %}">
+                        {% csrf_token %}
+                        {% if form.non_field_errors %}<div id="errorMsg">{{ form.non_field_errors }}</div>{% endif %}
+                        <table class="table table-sm table-striped">
+                            <thead>
                                 <tr>
-                                    <td>
-                                        <span class="icon-{{ provider_pair.provider.id }}">&nbsp;{{ provider_pair.name }}</span>
-                                    </td>
-                                    <td>
-                                        {% if existing_account %}{{ existing_account.username }}{% endif %}
-                                    </td>
-                                    <td>
-                                        {% if existing_account %}
-                                            <input id="id_account_{{ existing_account.id }}"
-                                                   type="hidden"
-                                                   name="account"
-                                                   value="{{ existing_account.id }}"/>
-                                            <button class="btn btn-sm border-0 btn-outline"
-                                                    title="Disconnect {{ provider_pair.name }} account"
-                                                    type="submit"
-                                                    hx-params="id_account_{{ existing_account.id }}">
-                                                <i class="fa fa-unlink text-danger"></i>
-                                            </button>
-                                        {% else %}
-                                            <button class="btn btn-sm border-0 btn-outline"
-                                                    type="submit"
-                                                    title="Connect {{ provider_pair.name }} account"
-                                                    hx-target="#connect_modal"
-                                                    hx-swap="innerHTML"
-                                                    hx-vals='{"next": "/ui/account/details"}'
-                                                    hx-get="{% provider_login_url provider_pair.provider.id process="connect" scope=scope auth_params=auth_params %}">
-                                                <i class="fa fa-plus text-success"></i>
-                                            </button>
-                                        {% endif %}
-                                    </td>
+                                    <th scope="col">Provider</th>
+                                    <th scope="col">Account</th>
+                                    <th scope="col"></th>
                                 </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </form>
-            </div>
+                            </thead>
+                            <tbody class="table-group-divider">
+                                {% for provider_pair in socialaccount_providers %}
+                                    {% find_account provider_pair.provider.id as existing_account %}
+                                    <tr>
+                                        <td>
+                                            <span class="icon-{{ provider_pair.provider.id }}">&nbsp;{{ provider_pair.name }}</span>
+                                        </td>
+                                        <td>
+                                            {% if existing_account %}{{ existing_account.username }}{% endif %}
+                                        </td>
+                                        <td>
+                                            {% if existing_account %}
+                                                <input id="id_account_{{ existing_account.id }}"
+                                                       type="hidden"
+                                                       name="account"
+                                                       value="{{ existing_account.id }}"/>
+                                                <button class="btn btn-sm border-0 btn-outline"
+                                                        title="Disconnect {{ provider_pair.name }} account"
+                                                        type="submit"
+                                                        hx-params="id_account_{{ existing_account.id }}">
+                                                    <i class="fa fa-unlink text-danger"></i>
+                                                </button>
+                                            {% else %}
+                                                <button class="btn btn-sm border-0 btn-outline"
+                                                        type="submit"
+                                                        title="Connect {{ provider_pair.name }} account"
+                                                        hx-target="#connect_modal"
+                                                        hx-swap="innerHTML"
+                                                        hx-vals='{"next": "/ui/account/details"}'
+                                                        hx-get="{% provider_login_url provider_pair.provider.id process="connect" scope=scope auth_params=auth_params %}">
+                                                    <i class="fa fa-plus text-success"></i>
+                                                </button>
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </form>
+                </div>
+            {% endif %}
         </div>
-    {% endif %}
+    </div>
     {% include "socialaccount/snippets/login_extra.html" %}
     <div id="connect_modal"></div>
 </div>

--- a/functionary/ui/templates/partials/socialaccount/connections.html
+++ b/functionary/ui/templates/partials/socialaccount/connections.html
@@ -1,15 +1,7 @@
-{% extends "base.html" %}
-{% load static %}
 {% load socialaccount %}
 {% load social_helper %}
-{% block extra_style %}
-    <link rel="stylesheet" href="{% static 'css/brands.css' %}" />
-{% endblock extra_style %}
-{% block title %}
-    Account Connections
-{% endblock title %}
-{% block content %}
-    <h1>Account Connections</h1>
+<div id="social_account_connections">
+    <strong class="fs-4"><i class="fa fa-id-card fa-sm fa-fw pe-1"></i>Account Connections</strong>
     {% configured_providers as socialaccount_providers %}
     {% if not socialaccount_providers %}
         <p>No third party accounts available to connect</p>
@@ -17,7 +9,7 @@
         <p>Manage third party account login connections here.</p>
         <div class="row flex-nowrap">
             <div class="col-9">
-                <form hx-post="{% url 'socialaccount_connections' %}">
+                <form hx-post="{% url 'ui:account-disconnect-social' %}">
                     {% csrf_token %}
                     {% if form.non_field_errors %}<div id="errorMsg">{{ form.non_field_errors }}</div>{% endif %}
                     <table class="table table-sm table-striped">
@@ -36,7 +28,7 @@
                                         <span class="icon-{{ provider_pair.provider.id }}">&nbsp;{{ provider_pair.name }}</span>
                                     </td>
                                     <td>
-                                        {% if existing_account %}{{ existing_account.extra_data.username }}{% endif %}
+                                        {% if existing_account %}{{ existing_account.username }}{% endif %}
                                     </td>
                                     <td>
                                         {% if existing_account %}
@@ -48,7 +40,7 @@
                                                     title="Disconnect {{ provider_pair.name }} account"
                                                     type="submit"
                                                     hx-params="id_account_{{ existing_account.id }}">
-                                                <i class="fa fa-unlink text-danger" />
+                                                <i class="fa fa-unlink text-danger"></i>
                                             </button>
                                         {% else %}
                                             <button class="btn btn-sm border-0 btn-outline"
@@ -56,8 +48,9 @@
                                                     title="Connect {{ provider_pair.name }} account"
                                                     hx-target="#connect_modal"
                                                     hx-swap="innerHTML"
+                                                    hx-vals='{"next": "/ui/account/details"}'
                                                     hx-get="{% provider_login_url provider_pair.provider.id process="connect" scope=scope auth_params=auth_params %}">
-                                                <i class="fa fa-plus text-success" />
+                                                <i class="fa fa-plus text-success"></i>
                                             </button>
                                         {% endif %}
                                     </td>
@@ -71,4 +64,4 @@
     {% endif %}
     {% include "socialaccount/snippets/login_extra.html" %}
     <div id="connect_modal"></div>
-{% endblock content %}
+</div>

--- a/functionary/ui/templates/partials/token.html
+++ b/functionary/ui/templates/partials/token.html
@@ -1,18 +1,43 @@
 <div id="token">
     <strong class="fs-4"><i class="fa fa-id-badge fa-sm fa-fw pe-1"></i>Token</strong>
-    <div class="col-9">
-        <form >
-            {% csrf_token %}
-            <span class="col-7" data-token="{{ token.key }}">{{ token.key }}</span>
-            {% comment %} <span class="col-2"/> {% endcomment %}
-            <button class="btn btn-sm border-0 btn-outline"
-                    type="submit"
-                    title="Regenerate Token"
-                    hx-target="#token"
-                    hx-swap="outerHTML"
-                    hx-post="{% url 'ui:token-refresh' %}">
-                <icon class="fa fa-recycle text-success" />
-            </button>
-        </form>
+    <div class="ps-4">
+        <div class="form-switch py-3">
+            <input class="form-check-input"
+                   type="checkbox"
+                   name="show"
+                   role="switch"
+                   id="show-toggle"
+                   onclick="toggleToken()"/>
+            <label class="form-check-label" for="wrap-toggle">Show token</label>
+        </div>
+        <div class="col-9 py-1">
+            <form >
+                {% csrf_token %}
+                <span class="col-7 font-monospace d-none" data-token="{{ token.key }}">{{ token.key }}</span>
+                <span id="masked_token" class="col-7 font-monospace">****************************************</span>
+                <button class="btn btn-sm border-0 btn-outline"
+                        type="submit"
+                        title="Regenerate Token"
+                        hx-target="#token"
+                        hx-swap="outerHTML"
+                        hx-post="{% url 'ui:token-refresh' %}">
+                    <icon class="fa fa-recycle text-success" />
+                </button>
+            </form>
+        </div>
     </div>
 </div>
+<script>
+    function toggleToken() {
+        const class_name = "d-none"
+        const masked_token = document.getElementById("masked_token")
+        const is_hidden = masked_token.classList.contains(class_name)
+        if (is_hidden) {
+            masked_token.classList.remove(class_name)
+            masked_token.previousElementSibling.classList.add(class_name)
+        } else {
+            masked_token.classList.add(class_name)
+            masked_token.previousElementSibling.classList.remove(class_name)
+        }
+    }
+</script>

--- a/functionary/ui/templates/partials/token.html
+++ b/functionary/ui/templates/partials/token.html
@@ -1,0 +1,18 @@
+<div id="token">
+    <strong class="fs-4"><i class="fa fa-id-badge fa-sm fa-fw pe-1"></i>Token</strong>
+    <div class="col-9">
+        <form >
+            {% csrf_token %}
+            <span class="col-7">{{ token.key }}</span>
+            {% comment %} <span class="col-2"/> {% endcomment %}
+            <button class="btn btn-sm border-0 btn-outline"
+                    type="submit"
+                    title="Regenerate Token"
+                    hx-target="#token"
+                    hx-swap="outerHTML"
+                    hx-post="{% url 'ui:token-refresh' %}">
+                <icon class="fa fa-recycle text-success" />
+            </button>
+        </form>
+    </div>
+</div>

--- a/functionary/ui/templates/partials/token.html
+++ b/functionary/ui/templates/partials/token.html
@@ -3,7 +3,7 @@
     <div class="col-9">
         <form >
             {% csrf_token %}
-            <span class="col-7">{{ token.key }}</span>
+            <span class="col-7" data-token="{{ token.key }}">{{ token.key }}</span>
             {% comment %} <span class="col-2"/> {% endcomment %}
             <button class="btn btn-sm border-0 btn-outline"
                     type="submit"

--- a/functionary/ui/templatetags/social_helper.py
+++ b/functionary/ui/templatetags/social_helper.py
@@ -8,8 +8,8 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def find_account(context, provider_id: str) -> ProviderAccount | None:
-    """This tag checks the SocialAccounts in the form found in the
-    templates context and returns the desired ProviderAccount.
+    """This tag checks the SocialAccounts in the templates
+    context and returns the desired ProviderAccount.
 
     Args:
         context: the template's context, automatically passed in
@@ -18,10 +18,10 @@ def find_account(context, provider_id: str) -> ProviderAccount | None:
     Returns:
         The matching ProviderAccount or None
     """
-    if form := context.get("form"):
-        for account in form.accounts:
-            if account.provider == provider_id:
-                return account.get_provider_account().account
+    for account in context.get("socialaccounts", None):
+        if account["provider"] == provider_id:
+            return account
+
     return None
 
 

--- a/functionary/ui/tests/views/test_account.py
+++ b/functionary/ui/tests/views/test_account.py
@@ -1,0 +1,37 @@
+import re
+
+import pytest
+from django.urls import reverse
+
+from core.models import User
+
+
+def _get_token(response):
+    content = str(response.content)
+    token = re.match(r'^.*data-token="(?P<token>[a-z0-9]+)">\1<.*$', content)
+    return token.group("token") if token else None
+
+
+@pytest.fixture
+def user():
+    user_obj = User.objects.create(username="logged_in_user")
+
+    return user_obj
+
+
+@pytest.mark.django_db
+def test_token_and_refresh(client, user):
+    client.force_login(user)
+
+    detail_url = reverse("ui:account-detail")
+    response = client.get(detail_url)
+    old_token = _get_token(response)
+
+    assert old_token is not None
+
+    refresh_url = reverse("ui:token-refresh")
+    response = client.post(refresh_url)
+    new_token = _get_token(response)
+
+    assert new_token is not None
+    assert old_token != new_token

--- a/functionary/ui/urls.py
+++ b/functionary/ui/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls.static import static
 from django.urls import path
 
 from .views import (
+    account,
     build,
     environment,
     environment_select,
@@ -114,6 +115,16 @@ urlpatterns = [
         name="set-environment",
     ),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+
+account_urlpatterns = [
+    path("account/details", account.details, name="account-detail"),
+    path(
+        "account/disconnect_social",
+        account.disconnect_social,
+        name="account-disconnect-social",
+    ),
+    path("account/token/refresh", account.refresh_token, name="token-refresh"),
+]
 
 environment_urlpatterns = [
     path(
@@ -289,6 +300,7 @@ For example, there should be a list for all the URLs related to
 teams, environments, schedules, tasks, etc.
 
 """
+urlpatterns += account_urlpatterns
 urlpatterns += environment_urlpatterns
 urlpatterns += scheduling_urlpatterns
 urlpatterns += team_urlpatterns

--- a/functionary/ui/views/account.py
+++ b/functionary/ui/views/account.py
@@ -1,0 +1,53 @@
+from allauth.socialaccount import signals
+from allauth.socialaccount.models import SocialAccount
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
+from django.views.decorators.http import require_GET, require_POST
+from django_htmx.http import HttpResponseClientRefresh
+from rest_framework.authtoken.models import Token
+
+
+@login_required
+@require_GET
+def details(request):
+    account_data = []
+    for account in SocialAccount.objects.filter(user=request.user):
+        provider_account = account.get_provider_account()
+        account_data.append(
+            {
+                "id": account.pk,
+                "provider": account.provider,
+                "name": provider_account.to_str(),
+                "username": account.extra_data.get("username", None),
+            }
+        )
+
+    token, _ = Token.objects.get_or_create(user=request.user)
+    context = {"socialaccounts": account_data, "token": token}
+
+    return render(request, "account/details.html", context)
+
+
+@login_required
+@require_POST
+def disconnect_social(request):
+    accounts = SocialAccount.objects.filter(user=request.user)
+    account = accounts.filter(id=request.POST["account"])
+    if account:
+        account.delete()
+        signals.social_account_removed.send(
+            sender=SocialAccount, request=request, socialaccount=account
+        )
+
+    return HttpResponseClientRefresh()
+
+
+@login_required
+@require_POST
+def refresh_token(request):
+    if token := Token.objects.get(user=request.user):
+        token.delete()
+    new_token = Token.objects.create(user=request.user)
+    context = {"token": new_token}
+
+    return render(request, "partials/token.html", context)


### PR DESCRIPTION
This PR adds the ability to see and refresh the users token. This is useful if the user needs to remove a compromised token, or if you need to get a login token to make API calls over HTTP.

This change involved moving the social account connections page to a partial and adding a new account details page that also shows the token.  The social account delete view from django-allauth had to be circumvented because it would always redirect to a fixed URL instead of listening to the `next` parameter.

Closes #251 