### PR TITLE
#258 - Updated package definition and yaml template

### DIFF
--- a/cli/functionary/templates/package.yaml
+++ b/cli/functionary/templates/package.yaml
@@ -1,5 +1,7 @@
 # (required): schema version for the package definition
 version: 1.0
+
+# (required): The package metadata
 package:
   # (required) human-friendly unique identifier; cannot be changed
   name: "__PACKAGE_NAME__"
@@ -16,33 +18,34 @@ package:
   # (required) language that the functions are written in
   language: "__PACKAGE_LANGUAGE__"
 
-  functions:
-#    # similar to package level fields, but for the function
-#    - name: string
-#      summary: string
-#      display_name: string
-#      description: string
-#      # (optional) list of environment variables to set at runtime
-#      variables: list
-#      # (optional) data type of the functions return value
-#      return_type: string
+# (required): The list of functions and their associated metadata. 
+# Must define at least one function
+functions: []
+#   # similar to package level fields, but for the function
+#   - name: string
+#     summary: string
+#     display_name: string
+#     description: string
+#     # (optional) list of environment variables to set at runtime
+#     variables: []
+#     # (optional) data type of the functions return value
+#     return_type: string
 
-#      # (required) Parameters that the function takes
-#      parameters:
-#          # (required) should match the name of the parameter in the actual function signature
-#        - name: string
-#          # (optional) defaults to name; determines how the parameter is displayed in the UI
-#          display_name: string
-#          # (optional) detailed description
-#          description: string
-#          # (required) data type of the parameter
-#          type:  string
-#          # (optional) default value that will be used if none is provided
-#          default: string | num
-#          # (optional) whether the parameter is required
-#          required: bool
-
-#          # (optional) enumerate valid input options
-#          options:
-#            - name: string
-#              value: string | num
+#     # (required) Parameters that the function takes
+#     parameters:
+#         # (required) should match the name of the parameter in the actual function signature
+#       - name: string
+#         # (optional) defaults to name; determines how the parameter is displayed in the UI
+#         display_name: string
+#         # (optional) detailed description
+#         description: string
+#         # (required) data type of the parameter
+#         type:  string
+#         # (optional) default value that will be used if none is provided
+#         default: string | num
+#         # (optional) whether the parameter is required
+#         required: bool
+#         # (optional) enumerate valid input options
+#         options:
+#           - name: string
+#             value: string | num

--- a/examples/calculator/package.yaml
+++ b/examples/calculator/package.yaml
@@ -1,6 +1,8 @@
 # (required): schema version for the package portion of the yaml. This would inform which serializer / parser
 # to use in the event that we needed to make breaking changes to the way packages are defined.
 version: 1.0
+
+# (required): The package metadata
 package:
   # (required) human-friendly unique identifier (team + package name must be unique)
   name: calculator
@@ -16,21 +18,21 @@ package:
   # (required) Language that the functions are written in
   language: python
 
-  # (required)
-  functions:
-    # Similar to package level fields, but for the function
-    - name: add
-      summary: Add two integers
-      description: This function consumes two integers and outputs the sum.
-      return_type: integer
+# (required): The list of functions and their associated metadata
+functions:
+  # Similar to package level fields, but for the function
+  - name: add
+    summary: Add two integers
+    description: This function consumes two integers and outputs the sum.
+    return_type: integer
 
-      # (required) Parameters that the function takes
-      parameters:
-        - name: a
-          type: integer
-          default: 1
-          required: true
-        - name: b
-          type: integer
-          default: 1
-          required: true
+    # (required) Parameters that the function takes
+    parameters:
+      - name: a
+        type: integer
+        default: 1
+        required: true
+      - name: b
+        type: integer
+        default: 1
+        required: true

--- a/examples/demo/package.yaml
+++ b/examples/demo/package.yaml
@@ -1,108 +1,110 @@
 version: 1.0
+
 package:
   name: "demo"
   display_name: Functionality Demo
   summary: Provides functions that demo / test various available features
   language: "python"
-  functions:
-    - name: output_json
-      summary: Demonstrates JSON output rendering
-      display_name: Output JSON
-      description:
-        'Takes in a JSON blob and then simply returns that to demonstrate how
-        the JSON rendering works in the UI. To see table rendering, the input
-        should be a list formatted something like: [ { "param1": "value1",
-        "param2": "value2" }, { "param1": "value3", "param2": "value4" } ]'
-      parameters:
-        - name: input
-          summary: The JSON blob to render
-          type: json
-          required: true
-      return_type: json
-    - name: output_text
-      summary: Demonstrates text output rendering
-      display_name: Output Text
-      description:
-        Takes in a string and then simply returns that to demonstrate how string
-        results rendering works in the UI. CSV formatted text will provide the
-        option to be rendered as a table.
-      parameters:
-        - name: input
-          summary: The text to render
-          type: text
-          required: true
-      return_type: string
-    - name: long_running_process
-      display_name: Long Running Process
-      summary: Simulate a long running process
-      description:
-        Sleeps for the specified duration to simulate a long running process
-      parameters:
-        - name: duration
-          summary: How long, in seconds, that the function should run for
-          type: integer
-          required: false
-          default: 60
-    - name: variables
-      display_name: Display Variables
-      summary: Displays environment variables at runtime
-      description:
-        Displays all the environment variables that are available to the
-        function at runtime
-      variables:
-        - HOME
-        - USER
-      parameters: []
-    - name: num_chars
-      summary: Returns the number of characters in given file
-      display_name: Number of Characters
-      description: Returns the number of characters in given file
-      return_type: integer
-      parameters:
-        - name: file
-          display_name: File
-          summary: File to measure
-          description: Input file that will be measured
-          type: file
-          required: true
-        - name: other_param
-          display_name: Other Param
-          summary: Other param argument
-          description: Prints parameter
-          type: text
-          required: true
-    - name: parameter_types
-      summary: Test for parameter type form rendering and passthrough values
-      display_name: Parameter Types
-      description:
-        Function to test all of the supported parameter types. Intended to test
-        the UI form rendering for the different types, as well as what data
-        types and values get received by the underlying function.
-      parameters:
-        - name: boolean
-          type: boolean
-          required: False
-        - name: date
-          type: date
-          required: False
-        - name: datetime
-          type: datetime
-          required: False
-        - name: file
-          type: file
-          required: False
-        - name: float
-          type: float
-          required: False
-        - name: integer
-          type: integer
-          required: False
-        - name: json
-          type: json
-          required: False
-        - name: string
-          type: string
-          required: False
-        - name: text
-          type: text
-          required: False
+
+functions:
+  - name: output_json
+    summary: Demonstrates JSON output rendering
+    display_name: Output JSON
+    description:
+      'Takes in a JSON blob and then simply returns that to demonstrate how the
+      JSON rendering works in the UI. To see table rendering, the input should
+      be a list formatted something like: [ { "param1": "value1", "param2":
+      "value2" }, { "param1": "value3", "param2": "value4" } ]'
+    parameters:
+      - name: input
+        summary: The JSON blob to render
+        type: json
+        required: true
+    return_type: json
+  - name: output_text
+    summary: Demonstrates text output rendering
+    display_name: Output Text
+    description:
+      Takes in a string and then simply returns that to demonstrate how string
+      results rendering works in the UI. CSV formatted text will provide the
+      option to be rendered as a table.
+    parameters:
+      - name: input
+        summary: The text to render
+        type: text
+        required: true
+    return_type: string
+  - name: long_running_process
+    display_name: Long Running Process
+    summary: Simulate a long running process
+    description:
+      Sleeps for the specified duration to simulate a long running process
+    parameters:
+      - name: duration
+        summary: How long, in seconds, that the function should run for
+        type: integer
+        required: false
+        default: 60
+  - name: variables
+    display_name: Display Variables
+    summary: Displays environment variables at runtime
+    description:
+      Displays all the environment variables that are available to the function
+      at runtime
+    variables:
+      - HOME
+      - USER
+    parameters: []
+  - name: num_chars
+    summary: Returns the number of characters in given file
+    display_name: Number of Characters
+    description: Returns the number of characters in given file
+    return_type: integer
+    parameters:
+      - name: file
+        display_name: File
+        summary: File to measure
+        description: Input file that will be measured
+        type: file
+        required: true
+      - name: other_param
+        display_name: Other Param
+        summary: Other param argument
+        description: Prints parameter
+        type: text
+        required: true
+  - name: parameter_types
+    summary: Test for parameter type form rendering and passthrough values
+    display_name: Parameter Types
+    description:
+      Function to test all of the supported parameter types. Intended to test
+      the UI form rendering for the different types, as well as what data types
+      and values get received by the underlying function.
+    parameters:
+      - name: boolean
+        type: boolean
+        required: False
+      - name: date
+        type: date
+        required: False
+      - name: datetime
+        type: datetime
+        required: False
+      - name: file
+        type: file
+        required: False
+      - name: float
+        type: float
+        required: False
+      - name: integer
+        type: integer
+        required: False
+      - name: json
+        type: json
+        required: False
+      - name: string
+        type: string
+        required: False
+      - name: text
+        type: text
+        required: False

--- a/functionary/builder/api/v1/serializers/package_definition.py
+++ b/functionary/builder/api/v1/serializers/package_definition.py
@@ -58,7 +58,6 @@ class PackageDefinitionSerializer(serializers.Serializer):
     environment = serializers.DictField(
         child=serializers.CharField(), required=False, read_only=True
     )
-    functions = FunctionSerializer(many=True, allow_empty=False)
 
 
 class PackageDefinitionWithVersionSerializer(serializers.Serializer):
@@ -66,3 +65,4 @@ class PackageDefinitionWithVersionSerializer(serializers.Serializer):
 
     version = serializers.CharField()
     package = PackageDefinitionSerializer()
+    functions = FunctionSerializer(many=True, allow_empty=False)

--- a/functionary/builder/api/v1/views/publish.py
+++ b/functionary/builder/api/v1/views/publish.py
@@ -67,6 +67,7 @@ class PublishView(APIView, EnvironmentViewMixin):
                 f"Invalid package.yaml. Encountered error: {serializer.errors}"
             )
         package_definition = serializer.validated_data["package"]
+        package_definition["functions"] = serializer.validated_data["functions"]
 
         build = initiate_build(
             creator=request.user,


### PR DESCRIPTION
Closes #258 

## Introduced Changes
- Moved the list of functions definition out of `.packages.functions` to the root level of the `package.yaml`
  - This removes the nested indenting for the `functions` definition in the `package.yaml`, which doesn't need to exist since the `package.yaml` is already representative of a singular package
- Updated the `package.yaml` template in the `CLI` to reflect this change
- Updated existing example packages to reflect this change

## Testing
- Since the DRF serializers are handling the validation of the incoming data, no unit tests are required
- You can rebuilt the `demo` and `calculator` packages with the new templates, or you can create a new package with the CLI tool to view the updated template