### PR TITLE
#264 - Fix Tasking via API

### DIFF
--- a/functionary/core/api/v1/serializers/__init__.py
+++ b/functionary/core/api/v1/serializers/__init__.py
@@ -1,10 +1,8 @@
 from .function import FunctionSerializer  # noqa
 from .package import PackageSerializer  # noqa
 from .task import (  # noqa
-    TaskCreateByFunctionIdSerializer,
-    TaskCreateByFunctionNameSerializer,
-    TaskCreateByWorkflowIdSerializer,
     TaskCreateResponseSerializer,
+    TaskParameterSerializer,
     TaskResultSerializer,
     TaskSerializer,
 )

--- a/functionary/core/api/v1/utils.py
+++ b/functionary/core/api/v1/utils.py
@@ -1,14 +1,5 @@
-import json
 import re
-from collections import OrderedDict
 from typing import Union
-
-from django.core.files.uploadedfile import InMemoryUploadedFile
-from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
-
-from core.models import Function, Workflow
-from core.utils.parameter import PARAMETER_TYPE
 
 PREFIX = "param"
 SEPARATOR = r"\."
@@ -16,69 +7,8 @@ SEPARATOR = r"\."
 param_name_format = re.compile(rf"^({PREFIX}){SEPARATOR}(\w+)$")
 
 
-def parse_parameters(values: OrderedDict) -> None:
-    """Mutate given values to move all `param.` arguments in parameters field"""
-    _update_parameter_field_type(values)
-
-    # Avoid dictionary changed size error by wrapping items in list
-    for param, _ in list(values.items()):
-        if not (valid_param_name := get_parameter_name(param)):
-            continue
-
-        value = values.pop(param)
-        if type(value) == InMemoryUploadedFile:
-            value = value.name
-
-        values["parameters"][valid_param_name] = value
-
-
-def cast_parameters(values: OrderedDict) -> None:
-    """Parent method to cast parameters to necessary types"""
-    _cast_json_parameters(values)
-
-
 def get_parameter_name(parameter: str) -> Union[str, None]:
     """Return parameter name if parameter format is valid"""
     if not (param_name := param_name_format.match(parameter)):
         return None
     return param_name.group(2)
-
-
-def _cast_json_parameters(values: OrderedDict) -> None:
-    """Mutates all JSON parameter fields into python objects
-
-    Args:
-        values: An OrderedDict containing the values passed to the serializer
-
-    Returns:
-        None
-
-    Raises:
-        ValidationError: When a JSON parameter is not valid JSON
-    """
-    tasked_object: Union[Function, Workflow] = values["tasked_object"]
-    json_params = tasked_object.parameters.filter(parameter_type=PARAMETER_TYPE.JSON)
-
-    for json_param in json_params:
-        try:
-            if not values["parameters"].get(json_param.name):
-                continue
-
-            if type(values["parameters"][json_param.name]) == dict:
-                continue
-
-            values["parameters"][json_param.name] = json.loads(
-                values["parameters"][json_param.name]
-            )
-        except json.decoder.JSONDecodeError as err:
-            exception_map = {json_param.name: err.msg}
-            exc = ValidationError(exception_map)
-            raise serializers.ValidationError(serializers.as_serializer_error(exc))
-
-
-def _update_parameter_field_type(values: OrderedDict) -> None:
-    """Mutates the `parameters` field to a dictionary"""
-    if not values.get("parameters"):
-        values["parameters"] = {}
-    elif type(values.get("parameters")) == str:
-        values["parameters"] = json.loads(values["parameters"])

--- a/functionary/core/api/v1/views/task.py
+++ b/functionary/core/api/v1/views/task.py
@@ -144,7 +144,7 @@ class TaskViewSet(
         if len(invalid_parameters) > 0:
             raise ValidationError(
                 f"Invalid parameters provided: {invalid_parameters}. "
-                f"Remember to use the {RENDER_PREFIX} prefix for tasking parameters."
+                f"Remember to use the '{RENDER_PREFIX}' prefix for tasking parameters."
             )
 
     @extend_schema(

--- a/functionary/core/api/v1/views/task.py
+++ b/functionary/core/api/v1/views/task.py
@@ -1,10 +1,6 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError as DjangoValidationError
-from drf_spectacular.utils import (
-    PolymorphicProxySerializer,
-    extend_schema,
-    extend_schema_view,
-)
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import mixins, serializers, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, ValidationError
@@ -15,21 +11,79 @@ from rest_framework.response import Response
 from core.api import HEADER_PARAMETERS
 from core.api.permissions import HasEnvironmentPermissionForAction
 from core.api.v1.serializers import (
-    TaskCreateByFunctionIdSerializer,
-    TaskCreateByFunctionNameSerializer,
-    TaskCreateByWorkflowIdSerializer,
     TaskCreateResponseSerializer,
     TaskLogSerializer,
+    TaskParameterSerializer,
     TaskResultSerializer,
     TaskSerializer,
 )
 from core.api.v1.utils import PREFIX, SEPARATOR, get_parameter_name
 from core.api.viewsets import EnvironmentGenericViewSet
-from core.models import Task, TaskResult
+from core.models import Function, Task, TaskResult, Workflow
 from core.utils.minio import S3Error, handle_file_parameters
 from core.utils.tasking import start_task
 
 RENDER_PREFIX = f"{PREFIX}{SEPARATOR}".replace("\\", "")
+FUNCTION = "function"
+WORKFLOW = "workflow"
+FUNCTION_NAME = "function_name"
+PACKAGE_NAME = "package_name"
+
+# Getting drf-spectacular to handle "additionalProperties" for serializers proved
+# troublesome, so we construct the schema manually for now.
+TASK_CREATE_REQUEST_SCHEMA = {
+    "multipart/form-data": {
+        "oneOf": [
+            {
+                "type": "object",
+                "additionalProperties": True,
+                "properties": {
+                    FUNCTION: {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Function id",
+                    },
+                },
+                "required": [FUNCTION],
+            },
+            {
+                "type": "object",
+                "additionalProperties": True,
+                "properties": {
+                    FUNCTION_NAME: {
+                        "type": "string",
+                        "description": ("Function name"),
+                    },
+                    PACKAGE_NAME: {
+                        "type": "string",
+                        "description": ("Package name"),
+                    },
+                },
+                "required": [FUNCTION_NAME, PACKAGE_NAME],
+            },
+            {
+                "type": "object",
+                "additionalProperties": True,
+                "properties": {
+                    WORKFLOW: {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Workflow id",
+                    },
+                },
+                "required": [WORKFLOW],
+            },
+        ]
+    }
+}
+
+TASK_CREATE_REQUEST_DESCRIPTION = f"""
+Execute a function or workflow. The id of the entity being tasked must be supplied via
+either the `{FUNCTION}` or `{WORKFLOW}` parameter. Functions can alternatively be
+tasked by name using `{FUNCTION_NAME}` and `{PACKAGE_NAME}`. Parameters to be passed to
+the function or workflow are supplied by prefixing the parameter name with
+`{RENDER_PREFIX}`. For example `{RENDER_PREFIX}input`, `{RENDER_PREFIX}duration`, etc.
+"""
 
 
 @extend_schema_view(
@@ -49,37 +103,53 @@ class TaskViewSet(
     serializer_class = TaskSerializer
     permission_classes = [HasEnvironmentPermissionForAction]
 
-    def get_serializer_class(self):
-        if self.action == "create":
-            input_keys = self.request.data.keys()
-            if "function_name" in input_keys:
-                return TaskCreateByFunctionNameSerializer
-            elif "workflow" in input_keys:
-                return TaskCreateByWorkflowIdSerializer
+    def _get_tasked_object(self) -> Function | Workflow:
+        """Parses the requests data to determined the object being tasked"""
+        data = self.request.POST
+        input_keys = data.keys()
+
+        try:
+            if FUNCTION in input_keys:
+                return Function.objects.get(id=data[FUNCTION])
+            elif WORKFLOW in input_keys:
+                return Workflow.objects.get(id=data[WORKFLOW])
             else:
-                return TaskCreateByFunctionIdSerializer
-        else:
-            return self.serializer_class
+                return Function.objects.get(
+                    name=data.get(FUNCTION_NAME),
+                    package__name=data.get(PACKAGE_NAME),
+                )
+        except (ObjectDoesNotExist, DjangoValidationError):
+            raise ValidationError("Invalid function or workflow provided")
+
+    def _handle_extra_parameters(self, serializer: TaskParameterSerializer) -> None:
+        """Raises ValidationError if the request data includes unexpected input. This
+        is to ensure mistyped optional parameters are not silently ignored.
+        """
+        task_parameter_fields = list(serializer.fields.keys())
+        tasked_object_fields = [
+            FUNCTION,
+            WORKFLOW,
+            FUNCTION_NAME,
+            PACKAGE_NAME,
+        ]
+
+        valid_input = task_parameter_fields + tasked_object_fields
+
+        invalid_parameters = [
+            parameter
+            for parameter in self.request.POST.keys()
+            if parameter not in valid_input
+        ]
+
+        if len(invalid_parameters) > 0:
+            raise ValidationError(
+                f"Invalid parameters provided: {invalid_parameters}. "
+                f"Remember to use the {RENDER_PREFIX} prefix for tasking parameters."
+            )
 
     @extend_schema(
-        description=(
-            "Execute a function. The function to be executed can be defined either "
-            "by supplying function as a string uuid, or function_name and "
-            "package_name. "
-            "Parameters can be passed to the API either by prefixing them with "
-            f"`{RENDER_PREFIX}`, or placing them inside a `parameters` JSON "
-            "string. Prefixed parameters will **override** duplicate parameters "
-            "inside the parameters JSON string."
-        ),
-        request=PolymorphicProxySerializer(
-            component_name="TaskCreate",
-            serializers={
-                "function_by_id": TaskCreateByFunctionIdSerializer,
-                "function_by_name": TaskCreateByFunctionNameSerializer,
-                "workflow_by_id": TaskCreateByWorkflowIdSerializer,
-            },
-            resource_type_field_name=None,
-        ),
+        description=TASK_CREATE_REQUEST_DESCRIPTION,
+        request=TASK_CREATE_REQUEST_SCHEMA,
         responses={
             status.HTTP_201_CREATED: TaskCreateResponseSerializer,
         },
@@ -87,19 +157,21 @@ class TaskViewSet(
     )
     def create(self, request: Request, *args, **kwargs):
         data = request.data
+        tasked_object = self._get_tasked_object()
 
-        # Remove list elements that wrap singular values when multipart content
-        data = request.data.dict()
-
-        request_serializer: serializers.Serializer = self.get_serializer(data=data)
-        request_serializer.is_valid(raise_exception=True)
+        task_parameter_serializer = TaskParameterSerializer(
+            tasked_object=tasked_object, data=data
+        )
+        task_parameter_serializer.is_valid(raise_exception=True)
+        self._handle_extra_parameters(task_parameter_serializer)
 
         # TODO: Add API error handling when file upload fails.
         # Don't save file if upload fails.
         task = Task(
             creator=self.request.user,
             environment=self.get_environment(),
-            **request_serializer.validated_data,
+            tasked_object=tasked_object,
+            **task_parameter_serializer.validated_data,
         )
         try:
             task.clean()

--- a/functionary/core/utils/tasking.py
+++ b/functionary/core/utils/tasking.py
@@ -172,10 +172,10 @@ def _handle_workflow_run(workflow_run_step: WorkflowRunStep, task: Task) -> None
                 next_step.execute(workflow_task=workflow_task)
             else:
                 workflow_task.status = Task.COMPLETE
-                task.save()
+                workflow_task.save()
         case Task.ERROR:
             workflow_task.status = Task.ERROR
-            task.save()
+            workflow_task.save()
 
 
 def _handle_file_parameters(task: Task) -> None:


### PR DESCRIPTION
Closes #264 

This PR fixes tasking via the API by ensuring that the input parameters are properly deserialized.  Things happening here:

* It is no longer possible to provide the tasking parameters as a single `parameters` field with a json string.  This was incompatible with file tasking and managing both styles added needless complexity both from an implementation perspective and in communicating in the documentation how the endpoint works.  Now all function or workflow parameters *must* be provided as individual fields, prefixed with `param.` .
* Unexpected input now returns a 400 error.  This is to prevent situations where someone intends to provide an optional parameter and leaves off the `param.`, or mistypes the parameter as something like `param.inupt` instead of `param.input`.  These errors would be silently ignored before since the parameter they were intending to provide is optional anyway.  Now the api will reject such requests and return a 400.
* The various TaskCreateBy* serializers have been removed.  Instead, there is now just a `TaskParameterSerializer` which acts similarly to the `TaskParameterForm`.  It takes a Function or Workflow as input and then dynamically constructs the serializer fields based on the object's parameters.
* The Function or Workflow being tasked is now resolved in the view, since that needs to happen before the `TaskParameterSerializer` can be instantiated.
* The documentation for the POST /api/v1/tasks endpoint has been revamped.  Properly describing the additional properties in OpenAPI did not seem possible using drf-spectacular, so the schema is now constructed manually.
  * NOTE: Swagger does not handle `additionalProperties` for multipart/form-data and will not display fields for them.  It is thus still not possible to actually task via the swagger docs.  If you look at the redoc display instead (`api/docs/redoc/#tag/tasks/operation/tasks_create`) you can see "additional property" listed.  The endpoint description attempts to describe what those additional properties are.
* A few helper functions in `/api/v1/utils.py` were no longer being used and thus removed.
* The tests have been reworked and updated to break some tests out into individual function, fix some mistakes that were present, and add a few additional tests based on the new behavior.

## Test Instructions

* Unit tests are in place as described above.  Not every data type is tested, but the tests are at least more robust than what was there before.
* Try tasking through the API, providing various combinations of valid and invalid input.  The `parameter_types` example function is a good one for this since you can see how good and bad input for the various types is handled.   Here's a curl example for reference:

```shell
curl -X POST \
  'http://localhost:8000/api/v1/tasks/' \
  --header 'X-Environment-Id: 3764e110-2e14-4ab6-a8be-ee7b5b6345d6' \
  --header 'Authorization: Token <token goes here>' \
  --form 'function_name="parameter_types"' \
  --form 'package_name="demo"' \
  --form 'param.boolean="hey"' \
  --form 'param.float="notafloat"' \
  --form 'param.integer="notanint"' \
  --form 'param.json="{"hey": "yo""' \
  --form 'param.string="17"' \
  --form 'param.text="21"' \
  --form 'param.date="20230315"' \
  --form 'param.datetime="20230315T11:00:00Z"' \
  --form 'param.file="thisaintnofile"'
```

The response for the above would be:

```json
{
  "param.boolean": [
    "Must be a valid boolean."
  ],
  "param.date": [
    "Date has wrong format. Use one of these formats instead: YYYY-MM-DD."
  ],
  "param.datetime": [
    "Datetime has wrong format. Use one of these formats instead: YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z]."
  ],
  "param.file": [
    "The submitted data was not a file. Check the encoding type on the form."
  ],
  "param.float": [
    "A valid number is required."
  ],
  "param.integer": [
    "A valid integer is required."
  ],
  "param.json": [
    "Value must be valid JSON."
  ],
  "code": {
    "param.boolean": [
      "invalid"
    ],
    "param.date": [
      "invalid"
    ],
    "param.datetime": [
      "invalid"
    ],
    "param.file": [
      "invalid"
    ],
    "param.float": [
      "invalid"
    ],
    "param.integer": [
      "invalid"
    ],
    "param.json": [
      "invalid"
    ]
  }
}
```