### PR TITLE
Refactor get_users to reduce database calls.

### DIFF
--- a/functionary/ui/tests/views/environment/test_environment_utils.py
+++ b/functionary/ui/tests/views/environment/test_environment_utils.py
@@ -1,0 +1,218 @@
+import pytest
+
+from core.auth import Role
+from core.models import EnvironmentUserRole, Team, TeamUserRole, User
+from ui.views.environment.utils import get_members, get_user_role, get_user_roles
+
+
+@pytest.fixture
+def team():
+    team = Team.objects.create(name="team")
+    return team
+
+
+@pytest.fixture
+def environment(team):
+    return team.environments.get()
+
+
+@pytest.fixture
+def environment_no_users():
+    team = Team.objects.create(name="team_without_users")
+    return team.environments.get()
+
+
+@pytest.fixture
+def user_with_no_role():
+    user_obj = User.objects.create(username="no_role")
+
+    return user_obj
+
+
+@pytest.fixture
+def user_with_team_role(team):
+    user_obj = User.objects.create(username="with_team_role")
+
+    TeamUserRole.objects.create(user=user_obj, role=Role.OPERATOR.name, team=team)
+
+    return user_obj
+
+
+@pytest.fixture
+def user_with_env_role(environment):
+    user_obj = User.objects.create(username="with_env_role")
+
+    EnvironmentUserRole.objects.create(
+        user=user_obj, role=Role.DEVELOPER.name, environment=environment
+    )
+
+    return user_obj
+
+
+@pytest.fixture
+def user_with_env_admin_and_team_role(team, environment):
+    user_obj = User.objects.create(username="with_higher_env_role")
+
+    TeamUserRole.objects.create(user=user_obj, role=Role.READ_ONLY.name, team=team)
+    EnvironmentUserRole.objects.create(
+        user=user_obj, role=Role.ADMIN.name, environment=environment
+    )
+
+    return user_obj
+
+
+@pytest.fixture
+def user_with_team_admin_and_env_role(team, environment):
+    user_obj = User.objects.create(username="with_higher_team_role")
+
+    TeamUserRole.objects.create(user=user_obj, role=Role.ADMIN.name, team=team)
+    EnvironmentUserRole.objects.create(
+        user=user_obj, role=Role.DEVELOPER.name, environment=environment
+    )
+
+    return user_obj
+
+
+@pytest.fixture
+def user_with_both_roles(team, environment):
+    user_obj = User.objects.create(username="with_both_roles")
+
+    TeamUserRole.objects.create(user=user_obj, role=Role.DEVELOPER.name, team=team)
+    EnvironmentUserRole.objects.create(
+        user=user_obj, role=Role.DEVELOPER.name, environment=environment
+    )
+
+    return user_obj
+
+
+@pytest.mark.django_db
+def test_get_members_no_team(environment, user_with_env_role):
+    """returns the environment role when set"""
+    user_roles = get_members(environment)
+
+    assert len(user_roles) == 1
+    assert isinstance(user_roles[user_with_env_role], EnvironmentUserRole)
+
+
+@pytest.mark.django_db
+def test_get_members_only_team(environment, user_with_team_role):
+    """returns the team role if the user doesn't have an explicit environment role"""
+    user_roles = get_members(environment)
+
+    assert len(user_roles) == 1
+    assert isinstance(user_roles[user_with_team_role], TeamUserRole)
+
+
+@pytest.mark.django_db
+def test_get_members_both_roles(environment, user_with_both_roles):
+    """user with two equivalent roles returns the environment role"""
+    user_roles = get_members(environment)
+
+    assert len(user_roles) == 1
+    assert isinstance(user_roles[user_with_both_roles], EnvironmentUserRole)
+
+
+@pytest.mark.django_db
+def test_get_members_multiple_users(
+    environment,
+    user_with_team_role,
+    user_with_env_role,
+    user_with_both_roles,
+    user_with_env_admin_and_team_role,
+    user_with_team_admin_and_env_role,
+):
+    """returns a user role, but only the environment role when a
+    team role is also set"""
+    user_roles = get_members(environment)
+
+    assert len(user_roles) == 5
+    assert isinstance(user_roles[user_with_both_roles], EnvironmentUserRole)
+    assert isinstance(
+        user_roles[user_with_env_admin_and_team_role], EnvironmentUserRole
+    )
+    assert isinstance(
+        user_roles[user_with_team_admin_and_env_role], EnvironmentUserRole
+    )
+    assert isinstance(user_roles[user_with_env_role], EnvironmentUserRole)
+    assert isinstance(user_roles[user_with_team_role], TeamUserRole)
+
+
+@pytest.mark.django_db
+def test_get_user_role_without_roles(
+    environment_no_users,
+    user_with_env_role,
+    user_with_no_role,
+):
+    """None is returned for users without roles in an environment"""
+    user_role = get_user_role(user_with_env_role, environment_no_users)
+    assert user_role is None
+
+    user_role = get_user_role(user_with_no_role, environment_no_users)
+    assert user_role is None
+
+
+@pytest.mark.django_db
+def test_get_user_role_has_roles(
+    environment,
+    user_with_team_role,
+    user_with_env_role,
+):
+    """returnes the expected single role for the user"""
+    user_role = get_user_role(user_with_env_role, environment)
+    assert user_role == Role.DEVELOPER.name
+
+    user_role = get_user_role(user_with_team_role, environment)
+    assert user_role == Role.OPERATOR.name
+
+
+@pytest.mark.django_db
+def test_get_user_role_user_has_multiple_roles(
+    environment,
+    user_with_env_admin_and_team_role,
+    user_with_team_admin_and_env_role,
+    user_with_both_roles,
+):
+    """get_user_role returns the highest permission a user has"""
+    user_role = get_user_role(user_with_env_admin_and_team_role, environment)
+    assert user_role == Role.ADMIN.name
+
+    user_role = get_user_role(user_with_team_admin_and_env_role, environment)
+    assert user_role == Role.ADMIN.name
+
+    user_role = get_user_role(user_with_both_roles, environment)
+    assert user_role == Role.DEVELOPER.name
+
+
+@pytest.mark.django_db
+def test_get_user_roles(
+    environment,
+    user_with_team_role,
+    user_with_env_role,
+    user_with_both_roles,
+    user_with_env_admin_and_team_role,
+    user_with_team_admin_and_env_role,
+):
+    """environment with users is ordered by username and returns the
+    environment role when a team role is also present for a given user"""
+    user_roles = get_user_roles(environment)
+
+    assert len(user_roles) == 5
+    assert user_roles[0]["user"] == user_with_both_roles
+    assert user_roles[0]["environment_user_role_id"] > -1
+    assert user_roles[1]["user"] == user_with_env_role
+    assert user_roles[1]["environment_user_role_id"] > -1
+    assert user_roles[2]["user"] == user_with_env_admin_and_team_role
+    assert user_roles[2]["environment_user_role_id"] > -1
+    assert user_roles[2]["role"] == Role.ADMIN.name
+    assert user_roles[3]["user"] == user_with_team_admin_and_env_role
+    assert user_roles[3]["environment_user_role_id"] > -1
+    assert user_roles[3]["role"] == Role.DEVELOPER.name
+    assert user_roles[4]["user"] == user_with_team_role
+    assert user_roles[4]["environment_user_role_id"] is None
+
+
+@pytest.mark.django_db
+def test_get_user_roles_no_roles(environment_no_users):
+    """an environment without roles has no user roles"""
+    user_roles = get_user_roles(environment_no_users)
+    assert len(user_roles) == 0

--- a/functionary/ui/tests/views/team/test_team_utils.py
+++ b/functionary/ui/tests/views/team/test_team_utils.py
@@ -1,0 +1,115 @@
+import pytest
+
+from core.auth import Role
+from core.models import EnvironmentUserRole, Team, TeamUserRole, User
+from ui.views.team.utils import get_user_roles
+
+
+@pytest.fixture
+def team():
+    team = Team.objects.create(name="team")
+    return team
+
+
+@pytest.fixture
+def team_no_users():
+    team = Team.objects.create(name="team_without_users")
+    return team
+
+
+@pytest.fixture
+def environment(team):
+    return team.environments.get()
+
+
+@pytest.fixture
+def user_with_no_role():
+    user_obj = User.objects.create(username="no_role")
+
+    return user_obj
+
+
+@pytest.fixture
+def user_with_team_role(team):
+    user_obj = User.objects.create(username="with_team_role")
+
+    TeamUserRole.objects.create(user=user_obj, role=Role.OPERATOR.name, team=team)
+
+    return user_obj
+
+
+@pytest.fixture
+def user_with_env_role(environment):
+    user_obj = User.objects.create(username="with_env_role")
+
+    EnvironmentUserRole.objects.create(
+        user=user_obj, role=Role.DEVELOPER.name, environment=environment
+    )
+
+    return user_obj
+
+
+@pytest.fixture
+def user_with_env_admin_and_team_role(team, environment):
+    user_obj = User.objects.create(username="with_higher_env_role")
+
+    TeamUserRole.objects.create(user=user_obj, role=Role.READ_ONLY.name, team=team)
+    EnvironmentUserRole.objects.create(
+        user=user_obj, role=Role.ADMIN.name, environment=environment
+    )
+
+    return user_obj
+
+
+@pytest.fixture
+def user_with_team_admin_and_env_role(team, environment):
+    user_obj = User.objects.create(username="with_higher_team_role")
+
+    TeamUserRole.objects.create(user=user_obj, role=Role.ADMIN.name, team=team)
+    EnvironmentUserRole.objects.create(
+        user=user_obj, role=Role.DEVELOPER.name, environment=environment
+    )
+
+    return user_obj
+
+
+@pytest.fixture
+def user_with_both_roles(team, environment):
+    user_obj = User.objects.create(username="with_both_roles")
+
+    TeamUserRole.objects.create(user=user_obj, role=Role.DEVELOPER.name, team=team)
+    EnvironmentUserRole.objects.create(
+        user=user_obj, role=Role.DEVELOPER.name, environment=environment
+    )
+
+    return user_obj
+
+
+@pytest.mark.django_db
+def test_get_user_roles(
+    team,
+    user_with_no_role,
+    user_with_team_role,
+    user_with_env_role,
+    user_with_both_roles,
+    user_with_env_admin_and_team_role,
+    user_with_team_admin_and_env_role,
+):
+    """team with users is ordered by username and returns only the
+    team role for a given user"""
+    user_roles = get_user_roles(team)
+
+    assert len(user_roles) == 4
+    assert user_roles[0]["user"] == user_with_both_roles
+    assert user_roles[1]["user"] == user_with_env_admin_and_team_role
+    assert user_roles[1]["role"] == Role.READ_ONLY.name
+    assert user_roles[2]["user"] == user_with_team_admin_and_env_role
+    assert user_roles[2]["role"] == Role.ADMIN.name
+    assert user_roles[3]["user"] == user_with_team_role
+
+
+@pytest.mark.django_db
+def test_get_user_roles_no_roles(team_no_users):
+    """a team without roles has no user roles"""
+    user_roles = get_user_roles(team_no_users)
+    assert len(user_roles) == 0

--- a/functionary/ui/views/environment/detail.py
+++ b/functionary/ui/views/environment/detail.py
@@ -4,7 +4,7 @@ from django.views.generic.detail import DetailView
 from core.auth import Permission
 from core.models import Environment, Package, Variable
 
-from .utils import get_users
+from .utils import get_user_roles
 
 
 class EnvironmentDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
@@ -16,7 +16,7 @@ class EnvironmentDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView)
         env = self.get_object()
 
         context["packages"] = Package.objects.filter(environment=env)
-        context["user_details"] = get_users(env)
+        context["user_details"] = get_user_roles(env)
         context["environment_id"] = str(env.id)
         context["variables"] = (
             env.vars

--- a/functionary/ui/views/environment/user_role/create.py
+++ b/functionary/ui/views/environment/user_role/create.py
@@ -32,13 +32,12 @@ class EnvironmentUserRoleCreateView(PermissionedCreateView):
     def get_initial(self) -> dict:
         """Replace role in form with the user's effective role for the environment"""
         initial = super().get_initial()
-        user_id = self.request.GET.get("user_id")
-        if not user_id:
+        if not (user_id := self.request.GET.get("user_id")):
             return initial
 
         environment_id = self.kwargs.get("environment_pk")
         user = get_object_or_404(User, id=user_id)
         environment = get_object_or_404(Environment, id=environment_id)
-        user_role, _ = get_user_role(user, environment)
-        initial["role"] = user_role.role if user_role else None
+
+        initial["role"] = get_user_role(user, environment)
         return initial

--- a/functionary/ui/views/environment/user_role/update.py
+++ b/functionary/ui/views/environment/user_role/update.py
@@ -2,7 +2,6 @@ from django.urls import reverse
 
 from core.models import EnvironmentUserRole
 from ui.forms.environments import EnvironmentUserRoleForm
-from ui.views.environment.utils import get_user_role
 from ui.views.generic import PermissionedUpdateView
 
 
@@ -16,12 +15,3 @@ class EnvironmentUserRoleUpdateView(PermissionedUpdateView):
         return reverse(
             "ui:environment-detail", kwargs={"pk": self.kwargs.get("environment_pk")}
         )
-
-    def get_initial(self) -> dict:
-        environment_user_role: EnvironmentUserRole = self.get_object()
-        initial = super().get_initial()
-        if role := get_user_role(
-            environment_user_role.user, environment_user_role.environment
-        ):
-            initial["role"] = role
-        return initial

--- a/functionary/ui/views/environment/user_role/update.py
+++ b/functionary/ui/views/environment/user_role/update.py
@@ -20,8 +20,8 @@ class EnvironmentUserRoleUpdateView(PermissionedUpdateView):
     def get_initial(self) -> dict:
         environment_user_role: EnvironmentUserRole = self.get_object()
         initial = super().get_initial()
-        role, _ = get_user_role(
+        if role := get_user_role(
             environment_user_role.user, environment_user_role.environment
-        )
-        initial["role"] = role.role if role else initial["role"]
+        ):
+            initial["role"] = role
         return initial

--- a/functionary/ui/views/environment/utils.py
+++ b/functionary/ui/views/environment/utils.py
@@ -1,68 +1,46 @@
-from typing import Union
-
 from core.auth import Role
-from core.models import Environment, EnvironmentUserRole, Team, TeamUserRole, User
+from core.models import Environment, EnvironmentUserRole, TeamUserRole, User
 
 
-def get_user_role(
-    user: User, environment: Environment
-) -> tuple[
-    Union[EnvironmentUserRole, TeamUserRole, None], Union[Environment, Team, None]
-]:
+def get_user_role(user: User, environment: Environment) -> str | None:
     """Get the effective role of the user with respect to the Environment and Team
 
     This function returns the effective UserRole the user has within an environment,
     which is the highest role that user is currently assigned between the environment
-    and the team. This function also returns a reference to the environment or team
-    that their effective role is coming from.
+    and the team.
 
     If the user is not part of the environment, and they are not on the team,
-    returns a None for both return values.
-
-    If the user has an EnvironmentUserRole, and their permissions are
-    equivalent to their TeamUserRole, then the origin of their effective
-    role will always be from the Environment.
+    a None is returned.
 
     Args:
         user: User object for the user whose highest role you want to know
         environment: The target environment
 
     Returns:
-        userrole, team|environment: Return a tuple with the UserRole object and the
-            Environment or Team that role came from
-        None, None: Return a tuple filled with None if user was not part of the
-            team and environment
+        Return the string value of the Role or None
     """
 
-    if user not in get_env_members(environment) and user not in get_team_members(
-        environment
-    ):
-        return None, None
+    env_user_role = EnvironmentUserRole.objects.filter(
+        user=user, environment=environment
+    ).first()
+    team_user_role = TeamUserRole.objects.filter(
+        user=user, team=environment.team
+    ).first()
 
-    if (
-        env_user_role := EnvironmentUserRole.objects.filter(
-            user=user, environment=environment
-        ).first()
-    ) is None:
-        return (
-            TeamUserRole.objects.get(user=user, team=environment.team),
-            environment.team,
-        )
+    # Return None if neither exists
+    if not env_user_role and not team_user_role:
+        return None
 
-    if (
-        team_user_role := TeamUserRole.objects.filter(
-            user=user, team=environment.team
-        ).first()
-    ) is None:
-        return env_user_role, environment
+    # Otherwise make sure that a role value exists for both. It doesn't matter which
+    # role it comes from, just the greater value.
+    env_role = env_user_role.role if env_user_role else team_user_role.role
+    team_role = team_user_role.role if team_user_role else env_user_role.role
 
-    if Role[env_user_role.role] < Role[team_user_role.role]:
-        return team_user_role, environment.team
-    return env_user_role, environment
+    return team_role if Role[team_role] > Role[env_role] else env_role
 
 
-def get_users(env: Environment) -> list[dict]:
-    """Get list of users who are part of the environment
+def get_user_roles(env: Environment) -> list[dict]:
+    """Get list of roles for users who have access to the environment
 
     Get a list of users who have access to the environment. This includes
     the members of the team that the environment belongs to. The list will
@@ -72,28 +50,20 @@ def get_users(env: Environment) -> list[dict]:
         env: The environment to get users from
 
     Returns:
-        users: A list of dictionaries containing all the users who have
-            access to the environment.
+        A list of dictionaries containing all the users who have access
+        to the environment.
     """
-    env_members = get_env_members(env)
-    team_members = get_team_members(env)
-
-    # Use set to remove duplicate users
-    all_users = set(env_members + team_members)
+    role_members: dict[User, EnvironmentUserRole | TeamUserRole] = get_members(env)
 
     users = []
-    for user in all_users:
+    for user, role in role_members.items():
+        is_env_role = isinstance(role, EnvironmentUserRole)
         user_elements = {}
-        role, origin = get_user_role(user, env)
-        environment_user_role = EnvironmentUserRole.objects.filter(
-            environment=env, user=user
-        ).first()
+        origin = role.environment if is_env_role else role.team
         user_elements["user"] = user
         user_elements["role"] = role.role
         user_elements["origin"] = origin.name
-        user_elements["environment_user_role_id"] = (
-            environment_user_role.id if environment_user_role else None
-        )
+        user_elements["environment_user_role_id"] = role.id if is_env_role else None
         users.append(user_elements)
 
     # Sort users by their username in ascending order
@@ -101,35 +71,24 @@ def get_users(env: Environment) -> list[dict]:
     return users
 
 
-def get_env_members(
-    env: Environment,
-) -> list[User]:
-    """Get a list of all users in environment
+def get_members(env: Environment) -> dict[User, TeamUserRole | EnvironmentUserRole]:
+    """Get a dict of all users with roles that have access to the environment
 
-    Return a list of all users in the environment
-
-    Args:
-        env: The environment to get the users from
-
-    Returns:
-        members: A list of all members of the environment
-    """
-    members: list[User] = [user.user for user in env.user_roles.all()]
-    return members
-
-
-def get_team_members(
-    env: Environment,
-) -> list[User]:
-    """Get a list of all users in the env->team
-
-    Return a list of all users on the team that owns the environment
+    Return a dict of all users with their role that have permission to access
+    the environment either through a role on the team or environment.
 
     Args:
         env: The environment to get the users from
 
     Returns:
-        members: A list of all members of the env->team
+        A dict of all users with permission for the environment
     """
-    members: list[User] = [user.user for user in env.team.user_roles.all()]
+    roles = TeamUserRole.objects.filter(team=env.team).select_related("user", "team")
+    members: dict[User, TeamUserRole | EnvironmentUserRole] = {
+        role.user: role for role in roles
+    }
+    env_roles = EnvironmentUserRole.objects.filter(environment=env).select_related(
+        "user", "environment"
+    )
+    members.update({role.user: role for role in env_roles.all()})
     return members

--- a/functionary/ui/views/environment/utils.py
+++ b/functionary/ui/views/environment/utils.py
@@ -44,7 +44,7 @@ def get_user_roles(env: Environment) -> list[dict]:
 
     Get a list of users who have access to the environment. This includes
     the members of the team that the environment belongs to. The list will
-    be sorted in decending order based on role.
+    be sorted by user name.
 
     Args:
         env: The environment to get users from
@@ -75,7 +75,8 @@ def get_members(env: Environment) -> dict[User, TeamUserRole | EnvironmentUserRo
     """Get a dict of all users with roles that have access to the environment
 
     Return a dict of all users with their role that have permission to access
-    the environment either through a role on the team or environment.
+    the environment either through a role on the team or environment. A role
+    in the Environment overrides a Team role.
 
     Args:
         env: The environment to get the users from

--- a/functionary/ui/views/team/detail.py
+++ b/functionary/ui/views/team/detail.py
@@ -3,7 +3,7 @@ from django.views.generic.detail import DetailView
 
 from core.auth import Permission
 from core.models import Team, Variable
-from ui.views.team.utils import get_users
+from ui.views.team.utils import get_user_roles
 
 
 class TeamDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
@@ -12,7 +12,7 @@ class TeamDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         team: Team = self.get_object()
-        user_details = get_users(team)
+        user_details = get_user_roles(team)
 
         # Sort users by their username
         user_details.sort(key=lambda x: x["user"].username)

--- a/functionary/ui/views/team/utils.py
+++ b/functionary/ui/views/team/utils.py
@@ -1,20 +1,22 @@
 from core.models import Team, TeamUserRole
 
 
-def get_users(team: Team) -> list[dict]:
-    """Get user data about all the users in the team
+def get_user_roles(team: Team) -> list[dict]:
+    """Get role data about all the users in the team
 
-    Get a list of metadata about the users that are currently
+    Get a list of metadata about the user roles that are currently
     assigned to the given team.
 
     Args:
         team: The team to get the users from
 
     Returns:
-        user_details: A list of dictionaries that contains information
-            about the user and their relationship with the team
+        A list of dictionaries that contains information about
+        the user and their role in the team
     """
-    team_user_roles: list[TeamUserRole] = team.user_roles.all()
+    team_user_roles: list[TeamUserRole] = list(
+        TeamUserRole.objects.filter(team=team).select_related("user", "team").all()
+    )
 
     user_details = []
     for team_user_role in team_user_roles:

--- a/functionary/ui/views/team/utils.py
+++ b/functionary/ui/views/team/utils.py
@@ -2,7 +2,7 @@ from core.models import Team, TeamUserRole
 
 
 def get_user_roles(team: Team) -> list[dict]:
-    """Get role data about all the users in the team
+    """Get role data about all the users in the team.
 
     Get a list of metadata about the user roles that are currently
     assigned to the given team.
@@ -11,8 +11,8 @@ def get_user_roles(team: Team) -> list[dict]:
         team: The team to get the users from
 
     Returns:
-        A list of dictionaries that contains information about
-        the user and their role in the team
+        A list of dictionaries containing all the users who have access
+        to the team.
     """
     team_user_roles: list[TeamUserRole] = list(
         TeamUserRole.objects.filter(team=team).select_related("user", "team").all()
@@ -25,4 +25,7 @@ def get_user_roles(team: Team) -> list[dict]:
         user_element["role"] = team_user_role.role
         user_element["team_user_role_id"] = team_user_role.id
         user_details.append(user_element)
+
+    # Sort users by their username in ascending order
+    user_details.sort(key=lambda x: x["user"].username)
     return user_details


### PR DESCRIPTION
The current `get_users()` calls for Team and Environment detail pages query for all users multiple times. This PR updates the call to query once for everything that's needed for the call and return the appropriate values.