### PR TITLE
#269 - Fix TaskParameterTemplateForm template handling

### DIFF
--- a/functionary/core/models/workflow_step.py
+++ b/functionary/core/models/workflow_step.py
@@ -53,7 +53,6 @@ class WorkflowStep(models.Model):
         """Uses a given Context to resolve the parameter_template into a parameters
         dict
         """
-        # TODO: Disable autoescape rather than doing the .replace
         resolved_parameters = (
             Template(self.parameter_template or "{}")
             .render(context)
@@ -75,8 +74,11 @@ class WorkflowStep(models.Model):
         context = {"parameters": {}}
 
         parameters = workflow_run.parameters or {}
+
         for key, value in parameters.items():
-            context["parameters"][key] = json.dumps(value)
+            context["parameters"][key] = (
+                json.dumps(value) if isinstance(value, dict) else value
+            )
 
         for step in workflow_run.steps.all():
             name = step.workflow_step.name

--- a/functionary/core/models/workflow_step.py
+++ b/functionary/core/models/workflow_step.py
@@ -65,6 +65,10 @@ class WorkflowStep(models.Model):
         """Escapes characters to prepare for use in json"""
         return value.replace('"', '\\"') if isinstance(value, str) else value
 
+    def _get_json_safe_value(self, value):
+        """Converts a value into something json safe for use in the context"""
+        return json.dumps(value) if isinstance(value, dict) else self._escape(value)
+
     def _get_run_context(self, workflow_run: "Task") -> Context:
         """Generates a context for resolving tasking parameters.
 
@@ -80,16 +84,14 @@ class WorkflowStep(models.Model):
         parameters = workflow_run.parameters or {}
 
         for key, value in parameters.items():
-            context["parameters"][key] = (
-                json.dumps(value) if isinstance(value, dict) else self._escape(value)
-            )
+            context["parameters"][key] = self._get_json_safe_value(value)
 
         for step in workflow_run.steps.all():
             name = step.workflow_step.name
             task = step.step_task
 
             context[name] = {}
-            context[name]["result"] = task.result
+            context[name]["result"] = self._get_json_safe_value(task.result)
 
         return Context(context)
 

--- a/functionary/core/models/workflow_step.py
+++ b/functionary/core/models/workflow_step.py
@@ -53,11 +53,7 @@ class WorkflowStep(models.Model):
         """Uses a given Context to resolve the parameter_template into a parameters
         dict
         """
-        resolved_parameters = (
-            Template(self.parameter_template or "{}")
-            .render(context)
-            .replace("&quot;", '"')
-        )
+        resolved_parameters = Template(self.parameter_template or "{}").render(context)
 
         return json.loads(resolved_parameters)
 
@@ -93,7 +89,7 @@ class WorkflowStep(models.Model):
             context[name] = {}
             context[name]["result"] = self._get_json_safe_value(task.result)
 
-        return Context(context)
+        return Context(context, autoescape=False)
 
     def clean(self):
         if self.workflow.environment != self.function.package.environment:

--- a/functionary/core/models/workflow_step.py
+++ b/functionary/core/models/workflow_step.py
@@ -61,6 +61,10 @@ class WorkflowStep(models.Model):
 
         return json.loads(resolved_parameters)
 
+    def _escape(self, value):
+        """Escapes characters to prepare for use in json"""
+        return value.replace('"', '\\"') if isinstance(value, str) else value
+
     def _get_run_context(self, workflow_run: "Task") -> Context:
         """Generates a context for resolving tasking parameters.
 
@@ -77,7 +81,7 @@ class WorkflowStep(models.Model):
 
         for key, value in parameters.items():
             context["parameters"][key] = (
-                json.dumps(value) if isinstance(value, dict) else value
+                json.dumps(value) if isinstance(value, dict) else self._escape(value)
             )
 
         for step in workflow_run.steps.all():

--- a/functionary/core/tests/models/test_workflow_step.py
+++ b/functionary/core/tests/models/test_workflow_step.py
@@ -137,7 +137,7 @@ def test_workflow_step_generates_correct_task_parameters_for_str(workflow, funct
         parameter_template=parameter_template,
     )
 
-    quote = "This is the quote"
+    quote = 'This "quote" has quotes"'
     workflow_task_params = {"wf_str_param": quote}
 
     workflow_task = Task.objects.create(

--- a/functionary/core/tests/models/test_workflow_step.py
+++ b/functionary/core/tests/models/test_workflow_step.py
@@ -1,0 +1,152 @@
+import pytest
+
+from core.models import Function, Package, Task, Team, User, Workflow
+from core.utils.parameter import PARAMETER_TYPE
+
+
+@pytest.fixture
+def user():
+    return User.objects.create(username="user")
+
+
+@pytest.fixture
+def team():
+    return Team.objects.create(name="team")
+
+
+@pytest.fixture
+def environment(team):
+    return team.environments.get()
+
+
+@pytest.fixture
+def package(environment):
+    return Package.objects.create(name="testpackage", environment=environment)
+
+
+@pytest.fixture
+def function(package):
+    _function = Function.objects.create(
+        name="testfunction",
+        package=package,
+        environment=package.environment,
+        active=True,
+    )
+
+    _function.parameters.create(
+        name="func_int_param", parameter_type=PARAMETER_TYPE.INTEGER
+    )
+
+    _function.parameters.create(
+        name="func_json_param", parameter_type=PARAMETER_TYPE.JSON
+    )
+
+    _function.parameters.create(
+        name="func_str_param", parameter_type=PARAMETER_TYPE.STRING
+    )
+
+    return _function
+
+
+@pytest.fixture
+def workflow(environment, user):
+    _workflow = Workflow.objects.create(
+        environment=environment, name="workflow", creator=user
+    )
+
+    _workflow.parameters.create(
+        name="wf_json_param", parameter_type=PARAMETER_TYPE.JSON
+    )
+
+    _workflow.parameters.create(
+        name="wf_int_param", parameter_type=PARAMETER_TYPE.INTEGER
+    )
+
+    _workflow.parameters.create(
+        name="wf_str_param", parameter_type=PARAMETER_TYPE.STRING
+    )
+
+    return _workflow
+
+
+@pytest.mark.django_db
+def test_workflow_step_generates_correct_task_parameters_for_int(workflow, function):
+    """Integer workflow parameters are correctly translated to Task parameters"""
+    parameter_template = '{"func_int_param": {{parameters.wf_int_param}}}'
+
+    workflow_step = workflow.steps.create(
+        name="step1",
+        function=function,
+        parameter_template=parameter_template,
+    )
+
+    workflow_task_params = {"wf_int_param": 10}
+
+    workflow_task = Task.objects.create(
+        tasked_object=workflow,
+        creator=workflow.creator,
+        environment=workflow.environment,
+        parameters=workflow_task_params,
+    )
+
+    step_task = workflow_step.execute(workflow_task)
+
+    assert (
+        step_task.parameters["func_int_param"] == workflow_task_params["wf_int_param"]
+    )
+
+
+@pytest.mark.django_db
+def test_workflow_step_generates_correct_task_parameters_for_json(workflow, function):
+    """JSON workflow parameters are correctly translated to Task parameters"""
+    parameter_template = '{"func_json_param": {"nested": {{parameters.wf_json_param}}}}'
+
+    workflow_step = workflow.steps.create(
+        name="step1",
+        function=function,
+        parameter_template=parameter_template,
+    )
+
+    workflow_task_params = {"wf_json_param": {"this": "is a test"}}
+
+    workflow_task = Task.objects.create(
+        tasked_object=workflow,
+        creator=workflow.creator,
+        environment=workflow.environment,
+        parameters=workflow_task_params,
+    )
+
+    step_task = workflow_step.execute(workflow_task)
+
+    assert (
+        step_task.parameters["func_json_param"]["nested"]
+        == workflow_task_params["wf_json_param"]
+    )
+
+
+@pytest.mark.django_db
+def test_workflow_step_generates_correct_task_parameters_for_str(workflow, function):
+    """String workflow parameters are correctly translated to Task parameters"""
+    parameter_template = (
+        '{"func_str_param": "fun quote: \\"{{parameters.wf_str_param}}\\""}'
+    )
+
+    workflow_step = workflow.steps.create(
+        name="step1",
+        function=function,
+        parameter_template=parameter_template,
+    )
+
+    quote = "This is the quote"
+    workflow_task_params = {"wf_str_param": quote}
+
+    workflow_task = Task.objects.create(
+        tasked_object=workflow,
+        creator=workflow.creator,
+        environment=workflow.environment,
+        parameters=workflow_task_params,
+    )
+
+    step_task = workflow_step.execute(workflow_task)
+
+    assert step_task.parameters["func_str_param"] == f'fun quote: "{quote}"'


### PR DESCRIPTION
Closes #269 

This PR fixes a handful of issues related to workflow step parameters that use templating.

* It was not possible to edit steps that had json with a templated value.  For example: 
  `{"something": {{parameters.param1}}}`
* The same issue existed for other mixed template and non-template input.  With a string for example:
  `Today is a {{parameters.param1}} day`
* Numbers were sometimes treated as strings in the parameter template
* Strings that contained quotes were not properly handled.  For example:
  `here's a fun quote: "{{parameters.param1}}"`
* json template variables were sometimes rendered with quotes surrounding them.  These would be properly stripped, but could definitely be misleading / confusing to a user.

None of the above should be an issue with these changes.

## Test Instructions
* A small handful of unit tests have been added.  Some to test for conditions that were known to cause errors before, others to test things that some explored solutions were breaking in the process.
* To manually test, just try creating workflow steps that do some of the things described above.  Confirm that they behave as expected both in the editing process and when actually tasking.