### PR TITLE
Improve object list queries.

### DIFF
--- a/functionary/ui/forms/scheduled_task.py
+++ b/functionary/ui/forms/scheduled_task.py
@@ -65,7 +65,8 @@ class ScheduledTaskForm(ModelForm):
 
     def _update_function_queryset(self, environment: Environment):
         if environment:
-            self.fields["function"].queryset = Function.objects.filter(
+            function_field = self.fields["function"]
+            function_field.queryset = function_field.queryset.filter(
                 environment=environment, active=True
             )
 

--- a/functionary/ui/forms/workflow_step.py
+++ b/functionary/ui/forms/workflow_step.py
@@ -4,6 +4,7 @@ from django import forms
 from django.urls import reverse
 
 from core.models import WorkflowStep
+from core.models.workflow_step import VALID_STEP_NAME
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -46,12 +47,19 @@ class WorkflowStepCreateForm(forms.ModelForm):
                 "hx-swap": "innerHTML",
             }
         )
+        self.fields["name"].widget.attrs.update(
+            {
+                "pattern": VALID_STEP_NAME.regex.pattern,
+                "title": VALID_STEP_NAME.message,
+            }
+        )
 
-        # Narrow the available function list down to just those for the environment
-        if environment is not None:
+        # Narrow the available function list down to just those
+        # active in the environment
+        if environment:
             function_field = self.fields["function"]
             function_field.queryset = function_field.queryset.filter(
-                environment=environment
+                environment=environment, active=True
             )
 
 

--- a/functionary/ui/views/build.py
+++ b/functionary/ui/views/build.py
@@ -11,12 +11,15 @@ class BuildListView(PermissionedListView):
     ordering = ["-created_at"]
     table_class = BuildTable
     filterset_class = BuildFilter
+    queryset = Build.objects.select_related("package", "creator")
 
 
 class BuildDetailView(PermissionedDetailView):
     model = Build
     permissioned_model = "Package"
-    queryset = Build.objects.select_related("creator", "package").all()
+
+    def get_queryset(self):
+        return super().get_queryset().select_related("creator", "package", "buildlog")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/functionary/ui/views/environment/list.py
+++ b/functionary/ui/views/environment/list.py
@@ -14,3 +14,4 @@ class EnvironmentListView(LoginRequiredMixin, SingleTableMixin, FilterView):
     paginate_by = PAGINATION_AMOUNT
     template_name = "default_list.html"
     filterset_class = EnviromentFilter
+    queryset = Environment.objects.select_related("team")

--- a/functionary/ui/views/function.py
+++ b/functionary/ui/views/function.py
@@ -26,6 +26,7 @@ class FunctionListView(PermissionedListView):
     ordering = ["package__name", "name"]
     table_class = FunctionTable
     filterset_class = FunctionFilter
+    queryset = Function.objects.select_related("package")
 
 
 class FunctionDetailView(PermissionedDetailView):

--- a/functionary/ui/views/scheduled_task/detail.py
+++ b/functionary/ui/views/scheduled_task/detail.py
@@ -6,6 +6,13 @@ from ui.views.generic import PermissionedDetailView
 class ScheduledTaskDetailView(PermissionedDetailView):
     model = ScheduledTask
 
+    def get_queryset(self):
+        return (
+            super()
+            .get_queryset()
+            .select_related("creator", "function", "periodic_task__crontab")
+        )
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         scheduledtask: ScheduledTask = context["scheduledtask"]

--- a/functionary/ui/views/scheduled_task/list.py
+++ b/functionary/ui/views/scheduled_task/list.py
@@ -8,3 +8,10 @@ class ScheduledTaskListView(PermissionedListView):
     table_class = ScheduledTaskTable
     template_name = "core/scheduledtask_list.html"
     filterset_class = ScheduledTaskFilter
+    queryset = ScheduledTask.objects.select_related(
+        "environment",
+        "creator",
+        "most_recent_task",
+        "periodic_task",
+        "function",
+    )

--- a/functionary/ui/views/workflow/list.py
+++ b/functionary/ui/views/workflow/list.py
@@ -11,3 +11,4 @@ class WorkflowListView(PermissionedListView):
     table_class = WorkflowTable
     template_name = "core/workflow_list.html"
     filterset_class = WorkflowFilter
+    queryset = Workflow.objects.select_related("environment", "creator")


### PR DESCRIPTION
When upgrading to django-tables, we seem to have lost the queryset optimizations adding the related models to the querysets for the list view. This PR adds back the `queryset` definitions.

The details page for Workflows has extra calls but isn't worth the effort to fix it right now.