### PR TITLE
Switch variable add button to a GET request.

### DIFF
--- a/functionary/ui/templates/partials/variables_section.html
+++ b/functionary/ui/templates/partials/variables_section.html
@@ -19,7 +19,7 @@
                     type="button"
                     hx-target="#variable-list"
                     hx-swap="beforeend"
-                    hx-post="{% url 'ui:variable-create' parent_id=parent_object.id %}?all=true">
+                    hx-get="{% url 'ui:variable-create' parent_id=parent_object.id %}">
                 Add
             </button>
         {% endif %}

--- a/functionary/ui/views/variable.py
+++ b/functionary/ui/views/variable.py
@@ -92,12 +92,10 @@ class VariableView(LoginRequiredMixin, UserPassesTestMixin, View):
 
         return _render_variable_form(request, form, parent_id, add=True)
 
-    def get(self, request, pk):
-        variable = get_object_or_404(Variable, id=pk)
-        parent_id = (
-            variable.environment.id if variable.environment else variable.team.id
-        )
-        return _render_variable_row(request, parent_id, variable)
+    def get(self, request, parent_id):
+        form = VariableForm(parent_id)
+
+        return _render_variable_form(request, form, parent_id, add=True)
 
     def test_func(self):
         obj = (


### PR DESCRIPTION
Closes #267. Switch the Add Variable button to a GET request so the form doesn't pop up with the validation run on it.