### PR TITLE
Always show workflow parameters

### DIFF
--- a/functionary/ui/templates/core/workflow_detail.html
+++ b/functionary/ui/templates/core/workflow_detail.html
@@ -29,14 +29,12 @@
                 <p id="desc" class="ms-4 my-2">{{ workflow.description }}</p>
             </div>
         {% endif %}
-        {% if workflow.parameter %}
-            <div>
-                <h3 class="fw-semibold">
-                    <i class="fa fa-list fa-sm fa-fw me-1"></i>Parameters
-                </h3>
-                {% include "partials/workflows/parameter_list.html" %}
-            </div>
-        {% endif %}
+        <div>
+            <h3 class="fw-semibold">
+                <i class="fa fa-list fa-sm fa-fw me-1"></i>Parameters
+            </h3>
+            {% include "partials/workflows/parameter_list.html" %}
+        </div>
         <div>
             <h3 class="fw-semibold">
                 <i class="fa fa-stairs fa-sm fa-fw me-1"></i>Steps


### PR DESCRIPTION
This removes the logic check for deciding whether or not to show the workflow parameters, which was introduced in #282.  

First, the workflow parameters should never be hidden because if there are no parameters and we hide them, then there is no longer a way to add parameters, since the add mechanism is in the no longer rendered partial.

Second, as written the parameters would *always* be hidden because there was a typo in the check for parameters which resulted in it always being false.