### PR TITLE
Filter the UI selection of Functions and Packages to only the active objects.

### DIFF
--- a/examples/calculator/package.yaml
+++ b/examples/calculator/package.yaml
@@ -34,3 +34,48 @@ package:
           type: integer
           default: 1
           required: true
+    - name: subtract
+      summary: Subtracts two integers
+      description: This function consumes two integers and outputs the difference.
+      return_type: integer
+
+      # (required) Parameters that the function takes
+      parameters:
+        - name: a
+          type: integer
+          default: 1
+          required: true
+        - name: b
+          type: integer
+          default: 1
+          required: true
+    - name: multiply
+      summary: Multiplies two integers
+      description: This function consumes two integers and outputs the product.
+      return_type: integer
+
+      # (required) Parameters that the function takes
+      parameters:
+        - name: a
+          type: integer
+          default: 1
+          required: true
+        - name: b
+          type: integer
+          default: 1
+          required: true
+    - name: divide
+      summary: Divides two integers
+      description: This function divides two integers and returns the result.
+      return_type: float
+
+      # (required) Parameters that the function takes
+      parameters:
+        - name: a
+          type: integer
+          default: 1
+          required: true
+        - name: b
+          type: integer
+          default: 1
+          required: true

--- a/functionary/builder/models/build.py
+++ b/functionary/builder/models/build.py
@@ -67,6 +67,8 @@ class Build(ModelSaveHookMixin, models.Model):
         """Saves status as `COMPLETE`"""
         self._update_status(self.COMPLETE)
         self.package.complete()
+        # Two steps to ensure proper state transitions for packages.
+        self.package.enable()
 
     def in_progress(self):
         """Saves status as `IN_PROGRESS`"""

--- a/functionary/builder/models/build.py
+++ b/functionary/builder/models/build.py
@@ -68,7 +68,7 @@ class Build(ModelSaveHookMixin, models.Model):
         self._update_status(self.COMPLETE)
         self.package.complete()
         # Two steps to ensure proper state transitions for packages.
-        self.package.enable()
+        self.package.activate()
 
     def in_progress(self):
         """Saves status as `IN_PROGRESS`"""

--- a/functionary/core/api/v1/views/function.py
+++ b/functionary/core/api/v1/views/function.py
@@ -8,7 +8,7 @@ from ..serializers import FunctionSerializer
 class FunctionViewSet(EnvironmentReadOnlyModelViewSet):
     """View functions across all known packages"""
 
-    queryset = Function.objects.filter(active=True)
+    queryset = Function.active_objects.all()
     serializer_class = FunctionSerializer
     permission_classes = [HasEnvironmentPermissionForAction]
     environment_through_field = "package"

--- a/functionary/core/api/v1/views/package.py
+++ b/functionary/core/api/v1/views/package.py
@@ -8,6 +8,6 @@ from ..serializers import PackageSerializer
 class PackageViewSet(EnvironmentModelViewSet):
     """View for retrieving and updating packages"""
 
-    queryset = Package.objects.all()
+    queryset = Package.active_objects.all()
     serializer_class = PackageSerializer
     permission_classes = [HasEnvironmentPermissionForAction]

--- a/functionary/core/models/__init__.py
+++ b/functionary/core/models/__init__.py
@@ -1,7 +1,7 @@
 from .environment import Environment  # noqa
 from .function import Function  # noqa
 from .mixins import ModelSaveHookMixin  # noqa
-from .package import Package  # noqa
+from .package import PACKAGE_STATUS, Package  # noqa
 from .parameter import FunctionParameter, WorkflowParameter  # noqa
 from .scheduled_task import ScheduledTask  # noqa
 from .task import Task  # noqa

--- a/functionary/core/models/scheduled_task.py
+++ b/functionary/core/models/scheduled_task.py
@@ -104,11 +104,13 @@ class ScheduledTask(ModelSaveHookMixin, models.Model):
 
     def activate(self) -> None:
         self._enable_periodic_task()
-        self._update_status(self.ACTIVE)
+        if self.status in [self.PAUSED, self.PENDING]:
+            self._update_status(self.ACTIVE)
 
     def pause(self) -> None:
         self._disable_periodic_task()
-        self._update_status(self.PAUSED)
+        if self.status == self.ACTIVE:
+            self._update_status(self.PAUSED)
 
     def error(self) -> None:
         self._disable_periodic_task()

--- a/functionary/core/models/task.py
+++ b/functionary/core/models/task.py
@@ -110,7 +110,7 @@ class Task(models.Model):
 
     def _clean_tasked_object(self):
         """Validate tasked_object is active for newly created tasks"""
-        if self._state.adding and self.tasked_object.active is False:
+        if self._state.adding and not self.tasked_object.is_active():
             raise ValidationError("This function or workflow is not active")
 
     def clean(self):

--- a/functionary/core/models/task.py
+++ b/functionary/core/models/task.py
@@ -110,7 +110,7 @@ class Task(models.Model):
 
     def _clean_tasked_object(self):
         """Validate tasked_object is active for newly created tasks"""
-        if self._state.adding and not self.tasked_object.is_active():
+        if self._state.adding and not self.tasked_object.is_active:
             raise ValidationError("This function or workflow is not active")
 
     def clean(self):

--- a/functionary/core/models/workflow.py
+++ b/functionary/core/models/workflow.py
@@ -97,6 +97,7 @@ class Workflow(models.Model):
         # for scheduled_task in self.scheduled_tasks.all():
         #     scheduled_task.pause()
 
+    @property
     def is_active(self) -> bool:
         """Returns true if the workflow is active"""
         return self.active

--- a/functionary/core/models/workflow.py
+++ b/functionary/core/models/workflow.py
@@ -96,3 +96,7 @@ class Workflow(models.Model):
         # TODO: Once scheduled_tasks support workflows come back and do something like:
         # for scheduled_task in self.scheduled_tasks.all():
         #     scheduled_task.pause()
+
+    def is_active(self) -> bool:
+        """Returns true if the workflow is active"""
+        return self.active

--- a/functionary/core/tests/api/v1/views/test_task.py
+++ b/functionary/core/tests/api/v1/views/test_task.py
@@ -17,6 +17,7 @@ from core.models import (
     WorkflowParameter,
     WorkflowStep,
 )
+from core.models.package import ENABLED
 from core.utils.minio import S3FileUploadError
 from core.utils.parameter import PARAMETER_TYPE
 
@@ -29,7 +30,9 @@ def environment() -> Environment:
 
 @pytest.fixture
 def package(environment: Environment) -> Package:
-    return Package.objects.create(name="testpackage", environment=environment)
+    return Package.objects.create(
+        name="testpackage", environment=environment, status=ENABLED
+    )
 
 
 @pytest.fixture

--- a/functionary/core/tests/api/v1/views/test_task.py
+++ b/functionary/core/tests/api/v1/views/test_task.py
@@ -17,7 +17,7 @@ from core.models import (
     WorkflowParameter,
     WorkflowStep,
 )
-from core.models.package import ENABLED
+from core.models.package import PACKAGE_STATUS
 from core.utils.minio import S3FileUploadError
 from core.utils.parameter import PARAMETER_TYPE
 
@@ -31,7 +31,7 @@ def environment() -> Environment:
 @pytest.fixture
 def package(environment: Environment) -> Package:
     return Package.objects.create(
-        name="testpackage", environment=environment, status=ENABLED
+        name="testpackage", environment=environment, status=PACKAGE_STATUS.ACTIVE
     )
 
 

--- a/functionary/core/tests/models/test_function.py
+++ b/functionary/core/tests/models/test_function.py
@@ -2,7 +2,7 @@ import pytest
 from django_celery_beat.models import CrontabSchedule, PeriodicTask
 
 from core.models import Function, Package, ScheduledTask, Task, Team, User
-from core.models.package import DISABLED, ENABLED
+from core.models.package import PACKAGE_STATUS
 
 
 @pytest.fixture
@@ -23,14 +23,14 @@ def environment(team):
 @pytest.fixture
 def package(environment):
     return Package.objects.create(
-        name="testpackage", environment=environment, status=ENABLED
+        name="testpackage", environment=environment, status=PACKAGE_STATUS.ACTIVE
     )
 
 
 @pytest.fixture
 def disabled_package(environment):
     return Package.objects.create(
-        name="disabledpackage", environment=environment, status=DISABLED
+        name="disabledpackage", environment=environment, status=PACKAGE_STATUS.DISABLED
     )
 
 

--- a/functionary/core/tests/models/test_package.py
+++ b/functionary/core/tests/models/test_package.py
@@ -1,0 +1,56 @@
+import pytest
+
+from core.models import Package, Team
+from core.models.package import DISABLED, ENABLED
+
+
+@pytest.fixture
+def team():
+    return Team.objects.create(name="team")
+
+
+@pytest.fixture
+def environment(team):
+    return team.environments.get()
+
+
+@pytest.fixture
+def package(environment):
+    return Package.objects.create(
+        name="testpackage", environment=environment, status=ENABLED
+    )
+
+
+@pytest.fixture
+def disabled_package(environment):
+    return Package.objects.create(
+        name="disabledpackage", environment=environment, status=DISABLED
+    )
+
+
+@pytest.fixture
+def default_package(environment):
+    return Package.objects.create(name="defaultpackage", environment=environment)
+
+
+@pytest.mark.django_db
+def test_active_packages(package, disabled_package, default_package):
+    """This checks filtering of packages with the status of 'DISABLED'"""
+    assert package.status != DISABLED
+    assert disabled_package.status == DISABLED
+
+    active_packages = Package.active_objects.all()
+    assert len(active_packages) == 1
+    assert default_package not in active_packages
+    assert disabled_package not in active_packages
+    assert package in active_packages
+
+    package.disable()
+    active_packages = Package.active_objects.all()
+    assert len(active_packages) == 0
+
+    all_packages = Package.objects.all()
+    assert len(all_packages) == 3
+    assert default_package in all_packages
+    assert disabled_package in all_packages
+    assert package in all_packages

--- a/functionary/core/tests/models/test_package.py
+++ b/functionary/core/tests/models/test_package.py
@@ -1,7 +1,13 @@
 import pytest
+from django_celery_beat.models import CrontabSchedule, PeriodicTask
 
-from core.models import Package, Team
-from core.models.package import DISABLED, ENABLED
+from core.models import Function, Package, ScheduledTask, Task, Team, User
+from core.models.package import PACKAGE_STATUS
+
+
+@pytest.fixture
+def user():
+    return User.objects.create(username="user")
 
 
 @pytest.fixture
@@ -17,14 +23,14 @@ def environment(team):
 @pytest.fixture
 def package(environment):
     return Package.objects.create(
-        name="testpackage", environment=environment, status=ENABLED
+        name="testpackage", environment=environment, status=PACKAGE_STATUS.ACTIVE
     )
 
 
 @pytest.fixture
 def disabled_package(environment):
     return Package.objects.create(
-        name="disabledpackage", environment=environment, status=DISABLED
+        name="disabledpackage", environment=environment, status=PACKAGE_STATUS.DISABLED
     )
 
 
@@ -33,11 +39,54 @@ def default_package(environment):
     return Package.objects.create(name="defaultpackage", environment=environment)
 
 
+@pytest.fixture
+def function(package):
+    return Function.objects.create(
+        name="testfunction",
+        environment=package.environment,
+        package=package,
+        active=True,
+    )
+
+
+@pytest.fixture
+def task(function, environment, user):
+    return Task.objects.create(
+        function=function,
+        environment=environment,
+        parameters={"prop1": "value1"},
+        creator=user,
+    )
+
+
+@pytest.fixture
+def periodic_task():
+    return PeriodicTask.objects.create(
+        name="periodicTemp",
+        task="task1",
+        crontab=CrontabSchedule.objects.create(hour=7, minute=30, day_of_week=1),
+    )
+
+
+@pytest.fixture
+def scheduled_task(function, environment, user, periodic_task):
+    return ScheduledTask.objects.create(
+        name="testtask",
+        description="description",
+        creator=user,
+        function=function,
+        environment=environment,
+        parameters={"name": "input", "summary": "summary", "type": "text"},
+        periodic_task=periodic_task,
+        status=ScheduledTask.ACTIVE,
+    )
+
+
 @pytest.mark.django_db
 def test_active_packages(package, disabled_package, default_package):
-    """This checks filtering of packages with the status of 'DISABLED'"""
-    assert package.status != DISABLED
-    assert disabled_package.status == DISABLED
+    """This checks filtering of inactive packages"""
+    assert package.is_active
+    assert not disabled_package.is_active
 
     active_packages = Package.active_objects.all()
     assert len(active_packages) == 1
@@ -45,7 +94,7 @@ def test_active_packages(package, disabled_package, default_package):
     assert disabled_package not in active_packages
     assert package in active_packages
 
-    package.disable()
+    package.deactivate()
     active_packages = Package.active_objects.all()
     assert len(active_packages) == 0
 
@@ -54,3 +103,19 @@ def test_active_packages(package, disabled_package, default_package):
     assert default_package in all_packages
     assert disabled_package in all_packages
     assert package in all_packages
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("scheduled_task")
+def test_deactivate_package_pauses_schedules(package, function):
+    """This marks the package to inactive and causes scheduled tasks to pause"""
+    assert function.is_active is True
+    assert function.scheduled_tasks.filter(status=ScheduledTask.ACTIVE).exists()
+
+    package.deactivate()
+    assert function.active is True
+    assert function.is_active is False
+    assert package.is_active is False
+
+    for scheduled_t in function.scheduled_tasks.all():
+        assert scheduled_t.status == ScheduledTask.PAUSED

--- a/functionary/ui/forms/scheduled_task.py
+++ b/functionary/ui/forms/scheduled_task.py
@@ -36,7 +36,7 @@ class ScheduledTaskForm(ModelForm):
         initial="*",
         validators=[month_of_year_validator],
     )
-    function = ModelChoiceField(queryset=Function.objects.all(), required=True)
+    function = ModelChoiceField(queryset=Function.active_objects.all(), required=True)
 
     class Meta:
         model = ScheduledTask

--- a/functionary/ui/forms/workflow_step.py
+++ b/functionary/ui/forms/workflow_step.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Union
 from django import forms
 from django.urls import reverse
 
-from core.models import WorkflowStep
+from core.models import Function, WorkflowStep
 from core.models.workflow_step import VALID_STEP_NAME
 
 if TYPE_CHECKING:
@@ -58,8 +58,8 @@ class WorkflowStepCreateForm(forms.ModelForm):
         # active in the environment
         if environment:
             function_field = self.fields["function"]
-            function_field.queryset = function_field.queryset.filter(
-                environment=environment, active=True
+            function_field.queryset = Function.active_objects.filter(
+                environment=environment
             )
 
 

--- a/functionary/ui/tests/views/test_function.py
+++ b/functionary/ui/tests/views/test_function.py
@@ -7,6 +7,7 @@ from django.test.client import Client
 from django.urls import reverse
 
 from core.models import Function, FunctionParameter, Package, Task, Team
+from core.models.package import ENABLED
 from core.utils.minio import S3FileUploadError
 from core.utils.parameter import PARAMETER_TYPE
 
@@ -19,7 +20,9 @@ def environment():
 
 @pytest.fixture
 def package(environment):
-    return Package.objects.create(name="testpackage", environment=environment)
+    return Package.objects.create(
+        name="testpackage", environment=environment, status=ENABLED
+    )
 
 
 @pytest.fixture

--- a/functionary/ui/tests/views/test_function.py
+++ b/functionary/ui/tests/views/test_function.py
@@ -7,7 +7,7 @@ from django.test.client import Client
 from django.urls import reverse
 
 from core.models import Function, FunctionParameter, Package, Task, Team
-from core.models.package import ENABLED
+from core.models.package import PACKAGE_STATUS
 from core.utils.minio import S3FileUploadError
 from core.utils.parameter import PARAMETER_TYPE
 
@@ -21,7 +21,7 @@ def environment():
 @pytest.fixture
 def package(environment):
     return Package.objects.create(
-        name="testpackage", environment=environment, status=ENABLED
+        name="testpackage", environment=environment, status=PACKAGE_STATUS.ACTIVE
     )
 
 

--- a/functionary/ui/views/environment/detail.py
+++ b/functionary/ui/views/environment/detail.py
@@ -15,7 +15,7 @@ class EnvironmentDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView)
         context = super().get_context_data(**kwargs)
         env = self.get_object()
 
-        context["packages"] = Package.objects.filter(environment=env)
+        context["packages"] = Package.active_objects.filter(environment=env)
         context["user_details"] = get_user_roles(env)
         context["environment_id"] = str(env.id)
         context["variables"] = (

--- a/functionary/ui/views/function.py
+++ b/functionary/ui/views/function.py
@@ -26,13 +26,8 @@ class FunctionListView(PermissionedListView):
     ordering = ["package__name", "name"]
     table_class = FunctionTable
     filterset_class = FunctionFilter
-    queryset = Function.objects.select_related("package")
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["breadcrumb"] = "Function List"
-
-        return context
+    queryset = Function.active_objects.select_related("package")
+    extra_context = {"breadcrumb": "Function List"}
 
 
 class FunctionDetailView(PermissionedDetailView):

--- a/functionary/ui/views/package.py
+++ b/functionary/ui/views/package.py
@@ -8,12 +8,8 @@ class PackageListView(PermissionedListView):
     model = Package
     table_class = PackageTable
     filterset_class = PackageFilter
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["breadcrumb"] = "Package List"
-
-        return context
+    extra_context = {"breadcrumb": "Package List"}
+    queryset = Package.active_objects.all()
 
 
 class PackageDetailView(PermissionedDetailView):

--- a/functionary/ui/views/scheduled_task/create.py
+++ b/functionary/ui/views/scheduled_task/create.py
@@ -26,7 +26,7 @@ class ScheduledTaskCreateView(PermissionedCreateView):
 
     def get(self, *args, **kwargs):
         environment_id = self.request.session.get("environment_id")
-        if not Function.objects.filter(environment=environment_id).exists():
+        if not Function.active_objects.filter(environment=environment_id).exists():
             messages.warning(
                 self.request,
                 "No available functions to schedule in current environment.",

--- a/functionary/ui/views/workflow/step/create.py
+++ b/functionary/ui/views/workflow/step/create.py
@@ -38,7 +38,7 @@ class WorkflowStepCreateView(PermissionedCreateView):
         # Various parent class calls require the object be set
         self.object = None
 
-        function = Function.objects.get(id=self.request.POST.get("function"))
+        function = Function.active_objects.get(id=self.request.POST.get("function"))
         parameter_form = TaskParameterTemplateForm(
             tasked_object=function, data=self.request.POST
         )


### PR DESCRIPTION
The UI now filters out inactive Functions as well as active Functions of disabled Packages. When disabling a Package, the Scheduled Tasks for the Functions will also be paused. When enabling a Package, Scheduled Tasks for Functions will *not* be re-activated, this is a manual step.

Disabled Functions do not appear in the Function list when updating an existing Workflow Step or Scheduled Task. When the Package is re-enabled or the Function reactivated, it will show up in those lists again.

There were new tests added to cover these changes. You can manually test these changes out in the UI by starting a Django shell and manually deactivating/activating a Function or disabling/enabling a Package.
```python
from core.models import Package, package
ps = Package.active_objects.all()
ps
<QuerySet [<Package: calculator>, <Package: demo>]>
p=ps[1]
p.disable()
p.enable()
```


** NOTE **: All Functions will probably show up as inactive because the existing Packages are in the "COMPLETE" state. The Packages can be either republished or manually enabled in the shell as above.

Fixes #259.