### PR TITLE
#295 - Remove schema sections (again)

### DIFF
--- a/functionary/ui/templates/core/function_detail.html
+++ b/functionary/ui/templates/core/function_detail.html
@@ -89,14 +89,6 @@
                         {% endif %}
                     </div>
                 {% endif %}
-                <details {% if not form %}open{% endif %}>
-                    <summary>
-                        <h3 class="fw-semibold">Schema</h3>
-                    </summary>
-                    <div class="my-2">
-                        <ol class="json-container wrap-json" id="json-result" />
-                    </div>
-                </details>
             </div>
         </div>
     </div>

--- a/functionary/ui/templates/core/workflow_task.html
+++ b/functionary/ui/templates/core/workflow_task.html
@@ -76,15 +76,6 @@
                         {% endif %}
                     </div>
                 {% endif %}
-                <details {% if not form %}open{% endif %}>
-                    <summary>
-                        <h3 class="fw-semibold">Schema</h3>
-                    </summary>
-                    <div class="m-4">
-                        <ol class="mx-1 json-container wrap-json" id="json-result" />
-                        <pre class="has-background-link-light">{{ workflow.schema | pretty_json }}</pre>
-                    </div>
-                </details>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Previous changes that removed the schema sections from the tasking pages got accidentally removed during conflict resolution of a previous PR.  This corrects that.