### PR TITLE
#309 - Change navbar order

### DIFF
--- a/functionary/ui/templates/base.html
+++ b/functionary/ui/templates/base.html
@@ -59,9 +59,7 @@
                                 <div class="btn-group d-grid d-md-flex w-100">{% include "forms/environment_selector.html" %}</div>
                                 <hr class="w-100 border-white" />
                                 <div class="navbar-nav">
-                                    <a class="nav-link px-2 w-100"
-                                       href="{% url 'ui:task-list' %}"
-                                       title="Tasking">
+                                    <a class="nav-link px-2" href="{% url 'ui:task-list' %}" title="Tasking">
                                         <i class="fa fa-lg fa-clipboard-list fa-fw"></i>
                                         <span class="ms-1 d-none d-md-inline">Tasking</span>
                                     </a>
@@ -89,9 +87,7 @@
                                         <i class="fa fa-lg fa-cubes fa-fw"></i>
                                         <span class="ms-1 d-none d-md-inline">Packages</span>
                                     </a>
-                                    <a class="nav-link px-2 w-100"
-                                       href="{% url 'ui:build-list' %}"
-                                       title="Builds">
+                                    <a class="nav-link px-2" href="{% url 'ui:build-list' %}" title="Builds">
                                         <i class="fa fa-lg fa-wrench fa-fw"></i>
                                         <span class="ms-1 d-none d-md-inline">Builds</span>
                                     </a>

--- a/functionary/ui/templates/base.html
+++ b/functionary/ui/templates/base.html
@@ -65,23 +65,11 @@
                                         <i class="fa fa-lg fa-clipboard-list fa-fw"></i>
                                         <span class="ms-1 d-none d-md-inline">Tasking</span>
                                     </a>
-                                    <a class="nav-link px-2 w-100"
-                                       href="{% url 'ui:build-list' %}"
-                                       title="Builds">
-                                        <i class="fa fa-lg fa-wrench fa-fw"></i>
-                                        <span class="ms-1 d-none d-md-inline">Builds</span>
-                                    </a>
                                     <a class="nav-link px-2"
-                                       href="{% url 'ui:package-list' %}"
-                                       title="Packages">
-                                        <i class="fa fa-lg fa-cubes fa-fw"></i>
-                                        <span class="ms-1 d-none d-md-inline">Packages</span>
-                                    </a>
-                                    <a class="nav-link px-2"
-                                       href="{% url 'ui:function-list' %}"
-                                       title="Functions">
-                                        <i class="fa fa-lg fa-cube fa-fw"></i>
-                                        <span class="ms-1 d-none d-md-inline">Functions</span>
+                                       href="{% url 'ui:scheduledtask-list' %}"
+                                       title="Schedules">
+                                        <i class="fa fa-lg fa-clock fa-fw"></i>
+                                        <span class="ms-1 d-none d-md-inline">Schedules</span>
                                     </a>
                                     <a class="nav-link px-2"
                                        href="{% url 'ui:workflow-list' %}"
@@ -90,10 +78,22 @@
                                         <span class="ms-1 d-none d-md-inline">Workflows</span>
                                     </a>
                                     <a class="nav-link px-2"
-                                       href="{% url 'ui:scheduledtask-list' %}"
-                                       title="Schedules">
-                                        <i class="fa fa-lg fa-clock fa-fw"></i>
-                                        <span class="ms-1 d-none d-md-inline">Schedules</span>
+                                       href="{% url 'ui:function-list' %}"
+                                       title="Functions">
+                                        <i class="fa fa-lg fa-cube fa-fw"></i>
+                                        <span class="ms-1 d-none d-md-inline">Functions</span>
+                                    </a>
+                                    <a class="nav-link px-2"
+                                       href="{% url 'ui:package-list' %}"
+                                       title="Packages">
+                                        <i class="fa fa-lg fa-cubes fa-fw"></i>
+                                        <span class="ms-1 d-none d-md-inline">Packages</span>
+                                    </a>
+                                    <a class="nav-link px-2 w-100"
+                                       href="{% url 'ui:build-list' %}"
+                                       title="Builds">
+                                        <i class="fa fa-lg fa-wrench fa-fw"></i>
+                                        <span class="ms-1 d-none d-md-inline">Builds</span>
                                     </a>
                                 </div>
                             </nav>

--- a/functionary/ui/templates/builder/build_detail.html
+++ b/functionary/ui/templates/builder/build_detail.html
@@ -6,7 +6,7 @@
         <nav aria-label="breadcrumb mb-1">
             <ol class="breadcrumb my-1">
                 <li class="breadcrumb-item">
-                    <a href="{% url 'ui:build-list' %}">Build List</a>
+                    <a href="{% url 'ui:build-list' %}">Builds</a>
                 </li>
                 <li class="breadcrumb-item active" aria-current="page">{{ build.package.render_name }}</li>
             </ol>

--- a/functionary/ui/templates/core/function_detail.html
+++ b/functionary/ui/templates/core/function_detail.html
@@ -5,7 +5,7 @@
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb my-1 pb-1">
             <li class="breadcrumb-item">
-                <a href="{% url 'ui:function-list' %}">Function List</a>
+                <a href="{% url 'ui:function-list' %}">Functions</a>
             </li>
             <li class="breadcrumb-item">
                 <i class="fa fa-cubes"></i>

--- a/functionary/ui/templates/core/package_detail.html
+++ b/functionary/ui/templates/core/package_detail.html
@@ -4,7 +4,7 @@
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb my-1 pb-1">
                 <li class="breadcrumb-item">
-                    <a href="{% url 'ui:package-list' %}">Package List</a>
+                    <a href="{% url 'ui:package-list' %}">Packages</a>
                 </li>
                 <li class="breadcrumb-item active" aria-current="page">{{ package.render_name }}</li>
             </ol>

--- a/functionary/ui/templates/core/scheduledtask_detail.html
+++ b/functionary/ui/templates/core/scheduledtask_detail.html
@@ -5,7 +5,7 @@
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb my-1 pb-1">
             <li class="breadcrumb-item">
-                <a href="{% url 'ui:scheduledtask-list' %}">Schedule List</a>
+                <a href="{% url 'ui:scheduledtask-list' %}">Schedules</a>
             </li>
             <li class="breadcrumb-item active" aria-current="page">{{ scheduledtask.name }}</li>
         </ol>

--- a/functionary/ui/templates/core/scheduledtask_list.html
+++ b/functionary/ui/templates/core/scheduledtask_list.html
@@ -4,7 +4,7 @@
     <div class="d-flex justify-content-between  align-items-center">
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb mb-0">
-                <li class="breadcrumb-item active" aria-current="page">Schedule List</li>
+                <li class="breadcrumb-item active" aria-current="page">Schedules</li>
             </ol>
         </nav>
         <div>

--- a/functionary/ui/templates/core/task_detail.html
+++ b/functionary/ui/templates/core/task_detail.html
@@ -6,7 +6,7 @@
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb my-1 pb-1">
                 <li class="breadcrumb-item">
-                    <a href="{% url 'ui:task-list' %}">Task List</a>
+                    <a href="{% url 'ui:task-list' %}">Tasking</a>
                 </li>
                 <li class="breadcrumb-item active" aria-current="page">{{ task.function.render_name }}</li>
             </ol>

--- a/functionary/ui/templates/core/workflow_detail.html
+++ b/functionary/ui/templates/core/workflow_detail.html
@@ -3,7 +3,7 @@
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb my-1 pb-1">
             <li class="breadcrumb-item">
-                <a href="{% url 'ui:workflow-list' %}">Workflow List</a>
+                <a href="{% url 'ui:workflow-list' %}">Workflows</a>
             </li>
             <li class="breadcrumb-item active" aria-current="page">{{ workflow.name }}</li>
         </ol>

--- a/functionary/ui/templates/core/workflow_list.html
+++ b/functionary/ui/templates/core/workflow_list.html
@@ -3,7 +3,7 @@
     <div class="d-flex justify-content-between align-items-center">
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb mb-0">
-                <li class="breadcrumb-item active" aria-current="page">Workflow List</li>
+                <li class="breadcrumb-item active" aria-current="page">Workflows</li>
             </ol>
         </nav>
         <div>

--- a/functionary/ui/templates/core/workflow_task.html
+++ b/functionary/ui/templates/core/workflow_task.html
@@ -4,7 +4,7 @@
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb my-1 pb-1">
             <li class="breadcrumb-item">
-                <a href="{% url 'ui:workflow-list' %}">Workflow List</a>
+                <a href="{% url 'ui:workflow-list' %}">Workflows</a>
             </li>
             <li class="breadcrumb-item active" aria-current="page">{{ workflow.name }}</li>
         </ol>

--- a/functionary/ui/templates/forms/scheduled_task/scheduled_task_edit.html
+++ b/functionary/ui/templates/forms/scheduled_task/scheduled_task_edit.html
@@ -5,7 +5,7 @@
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb">
             <li class="breadcrumb-item">
-                <a href="{% url 'ui:scheduledtask-list' %}">Schedules List</a>
+                <a href="{% url 'ui:scheduledtask-list' %}">Schedules</a>
             </li>
             <li class="breadcrumb-item active" aria-current="page">
                 {% if update %}

--- a/functionary/ui/views/build.py
+++ b/functionary/ui/views/build.py
@@ -15,7 +15,7 @@ class BuildListView(PermissionedListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["breadcrumb"] = "Build List"
+        context["breadcrumb"] = "Builds"
 
         return context
 

--- a/functionary/ui/views/function.py
+++ b/functionary/ui/views/function.py
@@ -27,7 +27,7 @@ class FunctionListView(PermissionedListView):
     table_class = FunctionTable
     filterset_class = FunctionFilter
     queryset = Function.active_objects.select_related("package")
-    extra_context = {"breadcrumb": "Function List"}
+    extra_context = {"breadcrumb": "Functions"}
 
 
 class FunctionDetailView(PermissionedDetailView):

--- a/functionary/ui/views/package.py
+++ b/functionary/ui/views/package.py
@@ -8,7 +8,7 @@ class PackageListView(PermissionedListView):
     model = Package
     table_class = PackageTable
     filterset_class = PackageFilter
-    extra_context = {"breadcrumb": "Package List"}
+    extra_context = {"breadcrumb": "Packages"}
     queryset = Package.active_objects.all()
 
 

--- a/functionary/ui/views/task.py
+++ b/functionary/ui/views/task.py
@@ -146,7 +146,7 @@ class TaskListView(PermissionedListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["breadcrumb"] = "Task List"
+        context["breadcrumb"] = "Tasking"
 
         return context
 


### PR DESCRIPTION
Closes #309 

Re-order navbar to have more frequently used items higher up. Change breadcrumb verbiage to match navbar entry.