### PR TITLE
#308 - boolean sliders

### DIFF
--- a/functionary/ui/templates/builder/build_detail.html
+++ b/functionary/ui/templates/builder/build_detail.html
@@ -48,7 +48,7 @@
                                 <i class="fa fa-book fa-sm fa-fw me-1"></i>Build Log
                             </h3>
                             <div class="ms-4">
-                                <div class="form-switch my-3">
+                                <div class="form-check form-switch my-3">
                                     <input class="form-check-input"
                                            type="checkbox"
                                            name="wrap"

--- a/functionary/ui/templates/forms/scheduled_task/scheduled_task_edit.html
+++ b/functionary/ui/templates/forms/scheduled_task/scheduled_task_edit.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% load widget_tweaks %}
-{% load static %}
 {% block content %}
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb">

--- a/functionary/ui/templates/forms/variable_form.html
+++ b/functionary/ui/templates/forms/variable_form.html
@@ -22,9 +22,9 @@
             {% render_field form.name class="form-control" placeholder=form.name.name id="name-input" aria-describedby="nameError" %}
             <div id="nameError" class="text-danger">{{ form.name.errors }}</div>
         </div>
-        <div class="mb-3">
-            {% render_field form.protect class="form-check-input" type="checkbox" id="{{ form.protect.id_for_label }}" %}
-            <label class="form-check-label" for="wrap-toggle">Protect</label>
+        <div class="form-check form-switch mb-3">
+            {% render_field form.protect class="form-check-input" type="checkbox" role="switch" id="{{ form.protect.id_for_label }}" %}
+            <label class="form-check-label" for="{{ form.protect.id_for_label }}">Protect</label>
         </div>
         <div class="mb-3">
             <label for="description-input"

--- a/functionary/ui/templates/forms/workflow/parameter_edit.html
+++ b/functionary/ui/templates/forms/workflow/parameter_edit.html
@@ -26,9 +26,9 @@
             {% render_field form.parameter_type class="form-select" aria-label=form.parameter_type.label role="menu" %}
             <div class="text-danger">{{ form.parameter_type.errors }}</div>
         </div>
-        <div class="mb-3">
+        <div class="form-check form-switch mb-3">
+            {% render_field form.required class="form-check-input" role="switch" type="checkbox" %}
             <label class="form-check-label" for="{{ form.required.id_for_label }}">{{ form.required.label }}</label>
-            {% render_field form.required class="form-check-input" placeholder=form.required.label type="checkbox" %}
         </div>
         <input type="hidden" name="workflow" value="{{ workflow.id }}"/>
         {{ form.non_field_errors }}

--- a/functionary/ui/templates/partials/token.html
+++ b/functionary/ui/templates/partials/token.html
@@ -3,14 +3,14 @@
         <i class="fa fa-id-badge fa-sm fa-fw pe-1"></i>Token
     </h3>
     <div class="ms-4">
-        <div class="form-switch my-3">
+        <div class="form-check form-switch my-3">
             <input class="form-check-input"
                    type="checkbox"
                    name="show"
                    role="switch"
                    id="show-toggle"
                    onclick="toggleToken()"/>
-            <label class="form-check-label" for="wrap-toggle">Show token</label>
+            <label class="form-check-label" for="show-toggle">Show token</label>
         </div>
         <div class="col-9 my-1">
             <form >


### PR DESCRIPTION
Closes #308 

Use slider indicators in favor of check-boxes. Applied everywhere except function Create Task parameters as that is using default templates which were not configurable.