### PR TITLE
#322 - Login error navbar fix

### DIFF
--- a/functionary/ui/templates/base.html
+++ b/functionary/ui/templates/base.html
@@ -48,16 +48,16 @@
             <div class="row flex-nowrap">
                 <div class="col-auto px-lg-3 px-2 bg-primary shadow">
                     <div class="d-flex flex-column vh-100 sticky-top">
-                        {% if user.is_authenticated %}
-                            <nav class="navbar navbar-dark nav-pills flex-column mb-auto align-items-start">
-                                <a href="{% url 'ui:home' %}" class="navbar-brand">
-                                    <h1 class="mb-0">
-                                        <span class="display-2">F</span>
-                                        <span class="functionary-title fs-4 d-none d-md-inline">unctionary</span>
-                                    </h1>
-                                </a>
-                                <div class="btn-group d-grid d-md-flex w-100">{% include "forms/environment_selector.html" %}</div>
-                                <hr class="w-100 border-white" />
+                        <nav class="navbar navbar-dark nav-pills flex-column mb-auto align-items-start">
+                            <a href="{% url 'ui:home' %}" class="navbar-brand">
+                                <h1 class="mb-0">
+                                    <span class="display-2">F</span>
+                                    <span class="functionary-title fs-4 d-none d-md-inline">unctionary</span>
+                                </h1>
+                            </a>
+                            <div class="btn-group d-grid d-md-flex w-100">{% include "forms/environment_selector.html" %}</div>
+                            <hr class="w-100 border-white" />
+                            {% if user.is_authenticated %}
                                 <div class="navbar-nav">
                                     <a class="nav-link px-2 w-100"
                                        href="{% url 'ui:task-list' %}"

--- a/functionary/ui/templates/base.html
+++ b/functionary/ui/templates/base.html
@@ -55,7 +55,9 @@
                                     <span class="functionary-title fs-4 d-none d-md-inline">unctionary</span>
                                 </h1>
                             </a>
-                            <div class="btn-group d-grid d-md-flex w-100">{% include "forms/environment_selector.html" %}</div>
+                            {% if user.is_authenticated %}
+                                <div class="btn-group d-grid d-md-flex w-100">{% include "forms/environment_selector.html" %}</div>
+                            {% endif %}
                             <hr class="w-100 border-white" />
                             {% if user.is_authenticated %}
                                 <div class="navbar-nav">


### PR DESCRIPTION
Closes #322 

When attempting to login with a 3rd party account on the main login page and an error is thrown, the resulting error page had a bad looking nav bar (thin blue line, no contents). It now displays just the Logo and horizontal rule below the logo - nav links are still hidden as user was not authenticated.