### PR TITLE
Disable sorting on certain fields

### DIFF
--- a/functionary/ui/tables/build.py
+++ b/functionary/ui/tables/build.py
@@ -46,3 +46,4 @@ class BuildTable(tables.Table):
     class Meta(BaseMeta):
         model = Build
         fields = FIELDS
+        orderable = True

--- a/functionary/ui/tables/function.py
+++ b/functionary/ui/tables/function.py
@@ -20,6 +20,7 @@ class FunctionTable(tables.Table):
     name = tables.Column(
         linkify=lambda record: reverse("ui:function-detail", kwargs={"pk": record.id}),
         verbose_name="Function",
+        orderable=True,
     )
 
     def render_name(self, value, record):

--- a/functionary/ui/tables/meta.py
+++ b/functionary/ui/tables/meta.py
@@ -1,2 +1,3 @@
 class BaseMeta:
     attrs = {"class": "table table-striped"}
+    orderable = False

--- a/functionary/ui/tables/package.py
+++ b/functionary/ui/tables/package.py
@@ -16,6 +16,7 @@ class PackageTable(tables.Table):
     name = tables.Column(
         linkify=lambda record: reverse("ui:package-detail", kwargs={"pk": record.id}),
         verbose_name="Package",
+        orderable=True,
     )
 
     class Meta(BaseMeta):

--- a/functionary/ui/tables/schedule_task.py
+++ b/functionary/ui/tables/schedule_task.py
@@ -11,7 +11,7 @@ FIELDS = ("name", "function", "last_run", "schedule", "status")
 
 
 class ScheduledTaskFilter(django_filters.FilterSet):
-    name = django_filters.Filter(label="Scheduled Task", lookup_expr="startswith")
+    name = django_filters.Filter(label="Name", lookup_expr="startswith")
     function = django_filters.Filter(
         field_name="function__name", label="Function", lookup_expr="startswith"
     )
@@ -33,7 +33,6 @@ class ScheduledTaskTable(tables.Table):
         linkify=lambda record: reverse(
             "ui:scheduledtask-detail", kwargs={"pk": record.id}
         ),
-        verbose_name="Scheduled Task",
     )
     function = tables.Column(accessor="function__name", verbose_name="Function")
     last_run = tables.DateTimeColumn(
@@ -42,7 +41,9 @@ class ScheduledTaskTable(tables.Table):
         linkify=lambda record: generateLastRunUrl(record),
         format=DATETIME_FORMAT,
     )
-    schedule = tables.Column(accessor="periodic_task__crontab", verbose_name="Schedule")
+    schedule = tables.Column(
+        accessor="periodic_task__crontab", verbose_name="Schedule", orderable=False
+    )
     edit_button = tables.Column(
         accessor="id",
         orderable=False,
@@ -52,6 +53,7 @@ class ScheduledTaskTable(tables.Table):
     class Meta(BaseMeta):
         model = ScheduledTask
         fields = FIELDS
+        orderable = True
 
     def render_edit_button(self, value, record):
         return format_html(

--- a/functionary/ui/tables/task.py
+++ b/functionary/ui/tables/task.py
@@ -87,4 +87,3 @@ class TaskListTable(tables.Table):
     class Meta(BaseMeta):
         model = Task
         fields = ("name", "status", "creator", "created_at")
-        orderable = False

--- a/functionary/ui/tables/workflow.py
+++ b/functionary/ui/tables/workflow.py
@@ -20,6 +20,7 @@ class WorkflowTable(tables.Table):
     name = tables.Column(
         linkify=lambda record: reverse("ui:workflow-task", kwargs={"pk": record.id}),
         verbose_name="Workflow",
+        orderable=True,
     )
     edit_button = tables.Column(
         accessor="id",

--- a/functionary/ui/views/package.py
+++ b/functionary/ui/views/package.py
@@ -5,7 +5,10 @@ from .generic import PermissionedDetailView, PermissionedListView
 
 
 class PackageListView(PermissionedListView):
+    """List view for the Package model"""
+
     model = Package
+    ordering = ["name"]
     table_class = PackageTable
     filterset_class = PackageFilter
     extra_context = {"breadcrumb": "Packages"}

--- a/functionary/ui/views/scheduled_task/list.py
+++ b/functionary/ui/views/scheduled_task/list.py
@@ -4,7 +4,10 @@ from ui.views.generic import PermissionedListView
 
 
 class ScheduledTaskListView(PermissionedListView):
+    """List view for the ScheduledTask model"""
+
     model = ScheduledTask
+    ordering = ["name"]
     table_class = ScheduledTaskTable
     template_name = "core/scheduledtask_list.html"
     filterset_class = ScheduledTaskFilter


### PR DESCRIPTION
This PR disables sorting on summary and description fields, as well as the schedule field on the schedules list page.  It also assigns a default sort to some views that didn't have one.