### PR TITLE
Streamline crontab display in schedules list

### DIFF
--- a/functionary/ui/forms/scheduled_task.py
+++ b/functionary/ui/forms/scheduled_task.py
@@ -18,12 +18,6 @@ class ScheduledTaskForm(ModelForm):
     scheduled_hour = CharField(
         max_length=24 * 4, label="Hour", initial="*", validators=[hour_validator]
     )
-    scheduled_day_of_week = CharField(
-        max_length=64,
-        label="Day of Week",
-        initial="*",
-        validators=[day_of_week_validator],
-    )
     scheduled_day_of_month = CharField(
         max_length=31 * 4,
         label="Day of Month",
@@ -35,6 +29,12 @@ class ScheduledTaskForm(ModelForm):
         label="Month of Year",
         initial="*",
         validators=[month_of_year_validator],
+    )
+    scheduled_day_of_week = CharField(
+        max_length=64,
+        label="Day of Week",
+        initial="*",
+        validators=[day_of_week_validator],
     )
     function = ModelChoiceField(queryset=Function.active_objects.all(), required=True)
 

--- a/functionary/ui/tables/schedule_task.py
+++ b/functionary/ui/tables/schedule_task.py
@@ -63,11 +63,21 @@ class ScheduledTaskTable(tables.Table):
         )
 
     def render_schedule(self, value):
+        crontab = " ".join(
+            [
+                value.minute,
+                value.hour,
+                value.day_of_month,
+                value.month_of_year,
+                value.day_of_week,
+            ]
+        )
+
         return format_html(
             "<span tabindex='0' data-bs-toggle='popover' data-bs-trigger='hover focus' "
             + "data-bs-content='{}'>{}<i class='fa fa-xs fa-fw fa-info-circle text-info"
             + " ms-2'></i><span class='visually-hidden'>{}</span></span>",
             value.human_readable,
-            value,
+            crontab,
             value.human_readable,
         )


### PR DESCRIPTION
This PR streamlines the crontab display on the list page by removing the " (m/h/dM/MY/d) UTC" format suffix.  This was done for a few reasons:

* It was noisy and only questionably helpful
* The popover text that gives the human readable form feels like it makes that format helper text redundant anyway
* It caused weird wrapping on even moderately sized windows

Additionally, the order of the crontab input fields on the schedule create / edit page has been fixed to match the actual order of crontab values (both the standard syntax and the way the values are displayed on every other page).